### PR TITLE
Switch back to api.criticalmaps.net

### DIFF
--- a/CriticalMass/PLConstants.m
+++ b/CriticalMass/PLConstants.m
@@ -20,7 +20,7 @@ BOOL const kDebugInitialTabIndex = 0;
 BOOL const kDebugShowAppirater = NO;
 
 // Urls
-NSString *const kUrlService = @"https://criticalmaps-api.stephanlindauer.de/postv2";
+NSString *const kUrlService = @"https://api.criticalmaps.net/";
 
 // Notifications
 NSString *const kNotificationInitialGpsDataReceived = @"initialGpsDataReceived";


### PR DESCRIPTION
`postv2` is not needed anymore.
at some point we should probably think about more meaningful routes. ;)