### PR TITLE
Fix issue #31 clipped images

### DIFF
--- a/CriticalMass/RulesDetailViewController.swift
+++ b/CriticalMass/RulesDetailViewController.swift
@@ -35,7 +35,7 @@ class RulesDetailViewController: UIViewController {
         artworkAttachment.image = artWork
         let ratio = (artWork?.size.height ?? 1) / (artWork?.size.width ?? 1)
 
-        artworkAttachment.bounds.size = CGSize(width: view.bounds.size.width, height: view.bounds.size.width * ratio)
+        artworkAttachment.bounds.size = CGSize(width: view.bounds.width - 30, height: (view.bounds.width - 30) * ratio)
 
         let attributedString = NSMutableAttributedString()
         attributedString.append(NSAttributedString(attachment: artworkAttachment))

--- a/CriticalMass/RulesDetailViewController.swift
+++ b/CriticalMass/RulesDetailViewController.swift
@@ -29,20 +29,21 @@ class RulesDetailViewController: UIViewController {
 
     private func configureTextView() {
         let textView = UITextView(frame: view.bounds)
+        textView.contentInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
 
         let artworkAttachment = NSTextAttachment()
         let artWork = rule.artwork
         artworkAttachment.image = artWork
         let ratio = (artWork?.size.height ?? 1) / (artWork?.size.width ?? 1)
-
-        artworkAttachment.bounds.size = CGSize(width: view.bounds.width - 30, height: (view.bounds.width - 30) * ratio)
+        let artworkPadding = textView.contentInset.left + textView.contentInset.right + textView.textContainer.lineFragmentPadding
+        let artworkWidth = view.bounds.width - artworkPadding
+        artworkAttachment.bounds.size = CGSize(width: artworkWidth, height: artworkWidth * ratio)
 
         let attributedString = NSMutableAttributedString()
         attributedString.append(NSAttributedString(attachment: artworkAttachment))
         attributedString.append(NSAttributedString(string: rule.text))
 
         textView.attributedText = attributedString
-        textView.contentInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
         textView.isEditable = false
         textView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         textView.font = UIFont.preferredFont(forTextStyle: .body)


### PR DESCRIPTION
This PR fixes issue #31 

<img width="584" alt="bildschirmfoto 2019-02-11 um 20 47 49" src="https://user-images.githubusercontent.com/879754/52589106-55921d80-2e3e-11e9-9367-9cb4e806abaa.png">
<img width="504" alt="bildschirmfoto 2019-02-11 um 20 47 47" src="https://user-images.githubusercontent.com/879754/52589107-55921d80-2e3e-11e9-8edb-1dd6e5e34e47.png">


