### PR TITLE
Fixed missing location data on launch

### DIFF
--- a/CriticalMass/AppController.swift
+++ b/CriticalMass/AppController.swift
@@ -8,6 +8,11 @@
 import Foundation
 
 class AppController {
+    
+    init() {
+        loadInitialData()
+    }
+    
     private var requestManager: RequestManager = {
         let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
         return RequestManager(dataStore: MemoryDataStore(), locationProvider: LocationManager(), networkLayer: NetworkOperator(), deviceId: deviceId.md5, url: Constants.apiEndpoint)
@@ -56,4 +61,8 @@ class AppController {
 
         return rootViewController
     }()
+    
+    private func loadInitialData() {
+        requestManager.getData()
+    }
 }

--- a/CriticalMass/AppController.swift
+++ b/CriticalMass/AppController.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class AppController {
-    private lazy var requestManager: RequestManager = {
+    private var requestManager: RequestManager = {
         let deviceId = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
         return RequestManager(dataStore: MemoryDataStore(), locationProvider: LocationManager(), networkLayer: NetworkOperator(), deviceId: deviceId.md5, url: Constants.apiEndpoint)
     }()

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -33,6 +33,7 @@ public class RequestManager {
         self.locationProvider = locationProvider
         self.networkLayer = networkLayer
         configureTimer(with: interval)
+        getData()
     }
 
     private func configureTimer(with interval: TimeInterval) {

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -33,7 +33,6 @@ public class RequestManager {
         self.locationProvider = locationProvider
         self.networkLayer = networkLayer
         configureTimer(with: interval)
-        getData()
     }
 
     private func configureTimer(with interval: TimeInterval) {


### PR DESCRIPTION
The RequestManager was lazy initialized, which caused that it wasn't initialized before opening the chat. Removing the lazy keyword fixes that. 
Additionally, I added a request on App launch, to get data before the first timer event happens (after 12 seconds)

fixes #58 