### PR TITLE
Fixed decoding Android Messages

### DIFF
--- a/CriticalMass/ChatMessage.swift
+++ b/CriticalMass/ChatMessage.swift
@@ -10,4 +10,10 @@ import Foundation
 public struct ChatMessage: Codable, Equatable {
     var message: String
     var timestamp: TimeInterval
+    
+    var decodedMessage: String? {
+        return message
+            .replacingOccurrences(of: "+", with: " ")
+            .removingPercentEncoding
+    }
 }

--- a/CriticalMass/ChatMessageTableViewCell.swift
+++ b/CriticalMass/ChatMessageTableViewCell.swift
@@ -29,6 +29,6 @@ class ChatMessageTableViewCell: UITableViewCell, MessagesTableViewCell {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm"
         timeLabel?.text = formatter.string(from: date)
-        chatTextView?.text = message.message
+        chatTextView?.text = message.decodedMessage
     }
 }


### PR DESCRIPTION
The [Android app uses URL encoding](https://github.com/criticalmaps/criticalmaps-android/blob/d484b4b5266fdb81b7fd04e7c03adcf8878e8fc4/app/src/main/java/de/stephanlindauer/criticalmaps/model/ChatModel.java#L42)  for messages which currently doesn't get decoded properly. 

@stephanlindauer  is there a reason for the url encoding?