### PR TITLE
Improved message send 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog for Critical Maps iOS
 
 ### Fixed
 - Users can not send empty chat messages anymore.
+- A bug that prevented sending messages if the another network request is active
 
 ## [3.0.0] - 2019-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog for Critical Maps iOS
 
 ### Fixed
 - Users can not send empty chat messages anymore.
-- A bug that prevented sending messages if the another network request is active
+- A bug that prevented sending messages if another network request is active
 
 ## [3.0.0] - 2019-04-18
 

--- a/CriticalMass/NetworkLayer.swift
+++ b/CriticalMass/NetworkLayer.swift
@@ -11,4 +11,5 @@ protocol NetworkLayer {
     func get<T: Decodable>(with url: URL, decodable: T.Type, completion: @escaping (T?) -> Void)
     func get<T: Decodable>(with url: URL, decodable: T.Type, customDateFormatter: DateFormatter?, completion: @escaping (T?) -> Void)
     func post<T: Decodable>(with url: URL, decodable: T.Type, bodyData: Data, completion: @escaping (T?) -> Void)
+    func cancelActiveRequestIfNeeded()
 }

--- a/CriticalMass/NetworkLayer.swift
+++ b/CriticalMass/NetworkLayer.swift
@@ -11,5 +11,5 @@ protocol NetworkLayer {
     func get<T: Decodable>(with url: URL, decodable: T.Type, completion: @escaping (T?) -> Void)
     func get<T: Decodable>(with url: URL, decodable: T.Type, customDateFormatter: DateFormatter?, completion: @escaping (T?) -> Void)
     func post<T: Decodable>(with url: URL, decodable: T.Type, bodyData: Data, completion: @escaping (T?) -> Void)
-    func cancelActiveRequestIfNeeded()
+    func cancelActiveRequestsIfNeeded()
 }

--- a/CriticalMass/NetworkOperator.swift
+++ b/CriticalMass/NetworkOperator.swift
@@ -48,4 +48,8 @@ struct NetworkOperator: NetworkLayer {
         }
         task.resume()
     }
+
+    func cancelActiveRequestIfNeeded() {
+        session.invalidateAndCancel()
+    }
 }

--- a/CriticalMass/NetworkOperator.swift
+++ b/CriticalMass/NetworkOperator.swift
@@ -49,7 +49,7 @@ struct NetworkOperator: NetworkLayer {
         task.resume()
     }
 
-    func cancelActiveRequestIfNeeded() {
+    func cancelActiveRequestsIfNeeded() {
         session.invalidateAndCancel()
     }
 }

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -75,10 +75,12 @@ public class RequestManager {
 
     public func send(messages: [SendChatMessage], completion: (([String: ChatMessage]?) -> Void)? = nil) {
         let backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask {
+            completion?(nil)
             self.networkLayer.cancelActiveRequestIfNeeded()
         }
         let body = SendMessagePostBody(device: deviceId, messages: messages)
         guard let bodyData = try? JSONEncoder().encode(body) else {
+            completion?(nil)
             return
         }
         networkLayer.post(with: endpoint, decodable: ApiResponse.self, bodyData: bodyData) { response in

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -77,10 +77,8 @@ public class RequestManager {
         let backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask {
             self.networkLayer.cancelActiveRequestIfNeeded()
         }
-        hasActiveRequest = true
         let body = SendMessagePostBody(device: deviceId, messages: messages)
         guard let bodyData = try? JSONEncoder().encode(body) else {
-            hasActiveRequest = false
             return
         }
         networkLayer.post(with: endpoint, decodable: ApiResponse.self, bodyData: bodyData) { response in

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -76,7 +76,7 @@ public class RequestManager {
     public func send(messages: [SendChatMessage], completion: (([String: ChatMessage]?) -> Void)? = nil) {
         let backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask {
             completion?(nil)
-            self.networkLayer.cancelActiveRequestIfNeeded()
+            self.networkLayer.cancelActiveRequestsIfNeeded()
         }
         let body = SendMessagePostBody(device: deviceId, messages: messages)
         guard let bodyData = try? JSONEncoder().encode(body) else {

--- a/CriticalMassTests/RequestManagerTests.swift
+++ b/CriticalMassTests/RequestManagerTests.swift
@@ -47,6 +47,8 @@ class MockNetworkLayer: NetworkLayer {
             completion(mockResponse as? T)
         }
     }
+
+    func cancelActiveRequestIfNeeded() {}
 }
 
 class MockDataStore: DataStore {

--- a/CriticalMassTests/RequestManagerTests.swift
+++ b/CriticalMassTests/RequestManagerTests.swift
@@ -48,7 +48,7 @@ class MockNetworkLayer: NetworkLayer {
         }
     }
 
-    func cancelActiveRequestIfNeeded() {}
+    func cancelActiveRequestsIfNeeded() {}
 }
 
 class MockDataStore: DataStore {


### PR DESCRIPTION
There was a possible bug that could prevent sending messages and show a loading indicator for ever if another network request is active. 

I also added a background task identifier for sending chat message to make sure that the messages get send after a user closes the app