### PR TITLE
Chat Keyboard improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changelog for Critical Maps iOS
 
 - Users can not send empty chat messages anymore.
 - A bug that prevented sending messages if another network request is active
+- input dismissed when switching emoji keyboardcha
 
 ## [3.0.0] - 2019-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Changelog for Critical Maps iOS
 
 - Users can not send empty chat messages anymore.
 - A bug that prevented sending messages if another network request is active
-- input dismissed when switching emoji keyboardcha
+- input dismissed when switching to the emoji keyboard
 
 ## [3.0.0] - 2019-04-18
 

--- a/CriticalMass/ChatViewController.swift
+++ b/CriticalMass/ChatViewController.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class ChatViewController: UIViewController, ChatInputDelegate {
+    private let chatInputHeight: CGFloat = 64
+    
     private let chatInput = ChatInputView(frame: .zero)
     private let messagesTableViewController = MessagesTableViewController<ChatMessageTableViewCell>(style: .plain)
     private let chatManager: ChatManager
@@ -16,7 +18,7 @@ class ChatViewController: UIViewController, ChatInputDelegate {
     }()
 
     private lazy var chatInputHeightConstraint = {
-        NSLayoutConstraint(item: chatInput, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 64)
+        NSLayoutConstraint(item: chatInput, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: chatInputHeight)
     }()
 
     init(chatManager: ChatManager) {
@@ -97,7 +99,7 @@ class ChatViewController: UIViewController, ChatInputDelegate {
             bottomInset = 0
         }
 
-        chatInputHeightConstraint.constant = 64 + bottomInset
+        chatInputHeightConstraint.constant = chatInputHeight + bottomInset
     }
 
     @objc private func didTapTableView() {
@@ -109,10 +111,9 @@ class ChatViewController: UIViewController, ChatInputDelegate {
     @objc private func keyboardWillShow(notification: Notification) {
         let duration = notification.userInfo![UIResponder.keyboardAnimationDurationUserInfoKey] as! Double
         let curve = notification.userInfo![UIResponder.keyboardAnimationCurveUserInfoKey] as! UInt
-        let beginFrame = (notification.userInfo![UIResponder.keyboardFrameBeginUserInfoKey] as! NSValue).cgRectValue
         let endFrame = (notification.userInfo![UIResponder.keyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
 
-        chatInputBottomConstraint.constant = (endFrame.minY - beginFrame.minY) + (view.frame.maxY - chatInput.frame.maxY)
+        chatInputBottomConstraint.constant = endFrame.height - view.frame.height + chatInputHeight
         view.setNeedsUpdateConstraints()
         UIView.animate(withDuration: duration, delay: 0, options: UIView.AnimationOptions(rawValue: curve), animations: {
             self.view.layoutIfNeeded()

--- a/CriticalMass/ChatViewController.swift
+++ b/CriticalMass/ChatViewController.swift
@@ -36,6 +36,11 @@ class ChatViewController: UIViewController, ChatInputDelegate {
         configureMessagesTableViewController()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        chatInput.resignFirstResponder()
+    }
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
 

--- a/CriticalMass/TextFieldWithInsets.swift
+++ b/CriticalMass/TextFieldWithInsets.swift
@@ -60,11 +60,11 @@ class TextFieldWithInsets: UITextField {
     // sets the backgroundColor when input ends
     // kind of a hack sice the textField was always resetting its backgrundColor when it resigned firstResponder
     override func resignFirstResponder() -> Bool {
-        let canBecomeFirstResponder = super.canBecomeFirstResponder
-        if canBecomeFirstResponder {
+        let didResignFirstResponder = super.resignFirstResponder()
+        if didResignFirstResponder {
             setEditorBackgroundColor(to: textFieldBackgroundColor)
         }
-        return canBecomeFirstResponder
+        return didResignFirstResponder
     }
 
     override func textRect(forBounds bounds: CGRect) -> CGRect {


### PR DESCRIPTION
Currently, the keyboard is dismissed after the Chat disappeared. With this PR the we dismiss the keyboard on tapping the close button.

It also fixes #72 