### PR TITLE
Chat input view fixes

### DIFF
--- a/CriticalMass/ChatInputView.swift
+++ b/CriticalMass/ChatInputView.swift
@@ -53,8 +53,8 @@ class ChatInputView: UIView, UITextFieldDelegate {
         return button
     }()
 
-    private let separator: SeperatorView = {
-        let view = SeperatorView()
+    private let separator: SeparatorView = {
+        let view = SeparatorView()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/CriticalMass/ChatViewController.swift
+++ b/CriticalMass/ChatViewController.swift
@@ -113,7 +113,7 @@ class ChatViewController: UIViewController, ChatInputDelegate {
         let curve = notification.userInfo![UIResponder.keyboardAnimationCurveUserInfoKey] as! UInt
         let endFrame = (notification.userInfo![UIResponder.keyboardFrameEndUserInfoKey] as! NSValue).cgRectValue
 
-        chatInputBottomConstraint.constant = endFrame.height - view.frame.height + chatInputHeight
+        chatInputBottomConstraint.constant = -endFrame.height
         view.setNeedsUpdateConstraints()
         UIView.animate(withDuration: duration, delay: 0, options: UIView.AnimationOptions(rawValue: curve), animations: {
             self.view.layoutIfNeeded()

--- a/CriticalMass/ChatViewController.swift
+++ b/CriticalMass/ChatViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class ChatViewController: UIViewController, ChatInputDelegate {
     private let chatInputHeight: CGFloat = 64
-    
+
     private let chatInput = ChatInputView(frame: .zero)
     private let messagesTableViewController = MessagesTableViewController<ChatMessageTableViewCell>(style: .plain)
     private let chatManager: ChatManager

--- a/CriticalMass/NavigationOverlayViewController.swift
+++ b/CriticalMass/NavigationOverlayViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SeperatorView: UIView {}
+class SeparatorView: UIView {}
 class OverlayView: UIView {
     @objc
     dynamic var overlayBackgroundColor: UIColor? {
@@ -36,7 +36,7 @@ struct NavigationOverlayItem {
 class NavigationOverlayViewController: UIViewController {
     private var items: [NavigationOverlayItem]
     private var itemViews: [UIView] = []
-    private var separatorViews: [SeperatorView] = []
+    private var separatorViews: [SeparatorView] = []
 
     init(navigationItems: [NavigationOverlayItem]) {
         items = navigationItems
@@ -101,7 +101,7 @@ class NavigationOverlayViewController: UIViewController {
 
         separatorViews = (0 ..< items.count - 1)
             .map { _ in
-                let view = SeperatorView()
+                let view = SeparatorView()
                 return view
             }
         separatorViews.forEach(view.addSubview)
@@ -121,6 +121,10 @@ class NavigationOverlayViewController: UIViewController {
             navigationController.navigationBar.topItem?.setLeftBarButton(barbuttonItem, animated: false)
             present(navigationController, animated: true, completion: nil)
         }
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
     }
 
     @objc func didTapCloseButton(button _: UIBarButtonItem) {

--- a/CriticalMass/NavigationOverlayViewController.swift
+++ b/CriticalMass/NavigationOverlayViewController.swift
@@ -123,10 +123,6 @@ class NavigationOverlayViewController: UIViewController {
         }
     }
 
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        super.touchesBegan(touches, with: event)
-    }
-
     @objc func didTapCloseButton(button _: UIBarButtonItem) {
         presentedViewController?.dismiss(animated: true, completion: nil)
     }

--- a/CriticalMass/TextFieldWithInsets.swift
+++ b/CriticalMass/TextFieldWithInsets.swift
@@ -57,16 +57,6 @@ class TextFieldWithInsets: UITextField {
         return didBecomeFirstResponder
     }
 
-    // sets the backgroundColor when input ends
-    // kind of a hack sice the textField was always resetting its backgrundColor when it resigned firstResponder
-    override func resignFirstResponder() -> Bool {
-        let didResignFirstResponder = super.resignFirstResponder()
-        if didResignFirstResponder {
-            setEditorBackgroundColor(to: textFieldBackgroundColor)
-        }
-        return didResignFirstResponder
-    }
-
     override func textRect(forBounds bounds: CGRect) -> CGRect {
         return bounds.inset(by: insets)
     }

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -60,7 +60,6 @@ class ThemeController {
     private func styleNavigationOverlayComponents(with theme: ThemeDefining) {
         CustomButton.appearance(whenContainedInInstancesOf: [NavigationOverlayViewController.self]).highlightedTintColor = theme.titleTextColor.withAlphaComponent(0.6)
         CustomButton.appearance(whenContainedInInstancesOf: [NavigationOverlayViewController.self]).defaultTintColor = theme.titleTextColor
-        SeperatorView.appearance(whenContainedInInstancesOf: [NavigationOverlayViewController.self]).backgroundColor = theme.navigationOverlaySeperatorColor
         ChatNavigationButton.appearance().unreadMessagesBackgroundColor = .red
         ChatNavigationButton.appearance().unreadMessagesTextColor = .white
         OverlayView.appearance().overlayBackgroundColor = theme.navigationOverlayBackgroundColor
@@ -88,6 +87,7 @@ class ThemeController {
     }
 
     private func styleGlobalComponents(with theme: ThemeDefining) {
+        SeparatorView.appearance().backgroundColor = theme.separatorColor
         UIApplication.shared.delegate?.window??.tintColor = theme.tintColor
         UITextField.appearance().keyboardAppearance = theme.keyboardAppearance
         // NavigationBar

--- a/CriticalMass/ThemeDefining.swift
+++ b/CriticalMass/ThemeDefining.swift
@@ -19,7 +19,7 @@ protocol ThemeDefining {
     var secondaryTitleTextColor: UIColor { get }
     var switchTintColor: UIColor { get }
     var chatMessageInputTextViewBackgroundColor: UIColor { get }
-    var navigationOverlaySeperatorColor: UIColor { get }
+    var separatorColor: UIColor { get }
     var cellSelectedBackgroundViewColor: UIColor { get }
     var navigationBarIsTranslucent: Bool { get }
     var placeholderTextColor: UIColor { get }
@@ -65,7 +65,7 @@ struct LightTheme: ThemeDefining {
         return .gray500
     }
 
-    var navigationOverlaySeperatorColor: UIColor {
+    var separatorColor: UIColor {
         return .lightThemeNavigationOverlaySeperatorColor
     }
 
@@ -131,7 +131,7 @@ struct DarkTheme: ThemeDefining {
         return .gray100
     }
 
-    var navigationOverlaySeperatorColor: UIColor {
+    var separatorColor: UIColor {
         return .darkThemeNavigationOverlaySeperatorColor
     }
 

--- a/CriticalMassTests/ThemeControllerTests.swift
+++ b/CriticalMassTests/ThemeControllerTests.swift
@@ -291,15 +291,15 @@ class ThemeControllerTests: XCTestCase {
         XCTAssertEqual(chatTextColor, Theme.dark.style.secondaryTitleTextColor)
     }
 
-    func testSeperatorViewBackgroundColorShouldChangeToNavigationOverlaySeperatorColorWhenContainedInNavigationOverlayViewControllerAndNightModeWasSelected() {
+    func testSeperatorViewBackgroundColorShouldChangeToNavigationOverlaySeperatorColorWhenNightModeWasSelected() {
         // given
         let theme: Theme = .dark
         // when
         sut.changeTheme(to: theme)
         sut.applyTheme()
         // then
-        let backgroundColor = SeperatorView.appearance(whenContainedInInstancesOf: [NavigationOverlayViewController.self]).backgroundColor
-        XCTAssertEqual(backgroundColor, Theme.dark.style.navigationOverlaySeperatorColor)
+        let backgroundColor = SeparatorView.appearance().backgroundColor
+        XCTAssertEqual(backgroundColor, Theme.dark.style.separatorColor)
     }
 
     func testChatNavigationButtonUnreadMessagesBackgroundColorShouldChangeToRedWhenNightModeWasSelected() {


### PR DESCRIPTION
fixed:
- missing separator
- hidden by software keyboard on iPhone X devices
- missing placeholder after editing 

<img width="511" alt="Bildschirmfoto 2019-05-24 um 14 50 49" src="https://user-images.githubusercontent.com/7677738/58329580-32134180-7e35-11e9-96a9-85d3cfb6fc0c.png">