### PR TITLE
Fixed missing update after failed request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Changelog for Critical Maps iOS
 
+## [UNRELEASED]
+
+### Added
+
+### Updated
+
+### Fixed
+
+- A bug that stopped updating locations if one update request failed
+
 ## [3.1.0] - 2019-05-28
 
 ### Added

--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		98401AF721FBCA1100064DAE /* ChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98401AF621FBCA1100064DAE /* ChatInputView.swift */; };
 		985E94B9220796CB00AA991B /* NavigationOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985E94B8220796CB00AA991B /* NavigationOverlayViewController.swift */; };
 		98790021222DA7E600880334 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98790020222DA7E600880334 /* AppDelegate.swift */; };
+		988B12AD22A271FE0010FAED /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988B12AC22A271FE0010FAED /* Logger.swift */; };
 		9897086E220A3E9E0073BB02 /* SocialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9897086C220A3E9E0073BB02 /* SocialViewController.swift */; };
 		9897086F220A3E9E0073BB02 /* SocialViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9897086D220A3E9E0073BB02 /* SocialViewController.xib */; };
 		98970871220A4E180073BB02 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98970870220A4E180073BB02 /* CustomButton.swift */; };
@@ -216,6 +217,7 @@
 		98401AF621FBCA1100064DAE /* ChatInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInputView.swift; sourceTree = "<group>"; };
 		985E94B8220796CB00AA991B /* NavigationOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationOverlayViewController.swift; sourceTree = "<group>"; };
 		98790020222DA7E600880334 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		988B12AC22A271FE0010FAED /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		9897086C220A3E9E0073BB02 /* SocialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialViewController.swift; sourceTree = "<group>"; };
 		9897086D220A3E9E0073BB02 /* SocialViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SocialViewController.xib; sourceTree = "<group>"; };
 		98970870220A4E180073BB02 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 				94092748228321E60034E46B /* UITableView+Register.swift */,
 				94FCBD23226C57CA00F93F94 /* UITableViewController+FooterSize.swift */,
 				9810C381229830940011F718 /* RatingHelper.swift */,
+				988B12AC22A271FE0010FAED /* Logger.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -764,6 +767,7 @@
 				985E94B9220796CB00AA991B /* NavigationOverlayViewController.swift in Sources */,
 				98401AF721FBCA1100064DAE /* ChatInputView.swift in Sources */,
 				94FCBD28226C57CA00F93F94 /* UITableViewController+FooterSize.swift in Sources */,
+				988B12AD22A271FE0010FAED /* Logger.swift in Sources */,
 				94FCBD35226C57FA00F93F94 /* ThemeController.swift in Sources */,
 				94092749228321E60034E46B /* UITableView+Register.swift in Sources */,
 				9409274B228322FD0034E46B /* TypeNameProtocol.swift in Sources */,

--- a/CriticalMass/Logger.swift
+++ b/CriticalMass/Logger.swift
@@ -1,0 +1,20 @@
+//
+//  Logger.swift
+//  CriticalMaps
+//
+//  Created by Leonard Thomas on 6/1/19.
+//  Copyright © 2019 Pokus Labs. All rights reserved.
+//
+
+import Foundation
+import os.log
+
+class Logger {
+    static func log(_ type: OSLogType, log: OSLog, _ message: StaticString) {
+        if #available(iOS 12.0, *) {
+            os_log(type, log: log, message)
+        } else {
+            print(message)
+        }
+    }
+}

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -49,17 +49,15 @@ public class RequestManager {
     }
 
     private func defaultCompletion(for response: ApiResponse?) {
-        if let response = response {
-            DispatchQueue.main.async {
+        DispatchQueue.main.async {
+            defer {
                 self.hasActiveRequest = false
+            }
+            if let response = response {
                 self.dataStore.update(with: response)
 
                 Logger.log(.info, log: self.log, "Successfully finished API update")
-            }
-        } else {
-            DispatchQueue.main.async {
-                self.hasActiveRequest = false
-
+            } else {
                 Logger.log(.error, log: self.log, "API update failed")
             }
         }

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -65,7 +65,7 @@ public class RequestManager {
 
     private func updateData() {
         guard hasActiveRequest == false else {
-            Logger.log(.info, log: self.log, "Don't attempt to request new data because because a request is still active")
+            Logger.log(.info, log: log, "Don't attempt to request new data because because a request is still active")
             return
         }
         hasActiveRequest = true

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -64,7 +64,10 @@ public class RequestManager {
     }
 
     private func updateData() {
-        guard hasActiveRequest == false else { return }
+        guard hasActiveRequest == false else {
+            Logger.log(.info, log: self.log, "Don't attempt to request new data because because a request is still active")
+            return
+        }
         hasActiveRequest = true
         // We only use a post request if we have a location to post
         if let currentLocation = locationProvider.currentLocation {

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import os.log
 
 public class RequestManager {
     private struct SendLocationPostBody: Codable {
@@ -27,6 +28,8 @@ public class RequestManager {
     private var networkLayer: NetworkLayer
     private var idProvider: IDProvider
 
+    private var log = OSLog(subsystem: Bundle.main.bundleIdentifier!, category: "RequestManager")
+
     init(dataStore: DataStore, locationProvider: LocationProvider, networkLayer: NetworkLayer, interval: TimeInterval = 12.0, idProvider: IDProvider, url: URL) {
         endpoint = url
         self.idProvider = idProvider
@@ -41,6 +44,7 @@ public class RequestManager {
     }
 
     @objc private func timerDidUpdate(timer _: Timer) {
+        Logger.log(.info, log: log, "Timer did update")
         updateData()
     }
 
@@ -49,6 +53,14 @@ public class RequestManager {
             DispatchQueue.main.async {
                 self.hasActiveRequest = false
                 self.dataStore.update(with: response)
+
+                Logger.log(.info, log: self.log, "Successfully finished API update")
+            }
+        } else {
+            DispatchQueue.main.async {
+                self.hasActiveRequest = false
+
+                Logger.log(.error, log: self.log, "API update failed")
             }
         }
     }

--- a/CriticalMassTests/RequestManagerTests.swift
+++ b/CriticalMassTests/RequestManagerTests.swift
@@ -31,7 +31,7 @@ class RequestManagerTests: XCTestCase {
     }
 
     func testRespectingRequestRepeatTime() {
-        let numberOfExpectedRequests: TimeInterval = 2
+        let numberOfExpectedRequests: TimeInterval = 3
         let interval: TimeInterval = 0.3
         let setup = self.setup(interval: interval)
         XCTAssertEqual(setup.networkLayer.numberOfRequests, 0)


### PR DESCRIPTION
During yesterdays ride, my app was often stuck and didn't received any updates. Especially after coming back from background. 
I found a bug that we never set hasActiveRequests to false after a failed requests which could have caused that issue. The updated test case handles this case. 

I added some OSLogs for easier debugging in the future 
