### PR TITLE
DarkModelOverlayFix

### DIFF
--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -75,7 +75,7 @@ class MapViewController: UIViewController {
             return
         }
         tileRenderer = MKTileOverlayRenderer(tileOverlay: nightThemeOverlay)
-        mapView.addOverlay(nightThemeOverlay, level: .aboveLabels)
+        mapView.addOverlay(nightThemeOverlay, level: .aboveRoads)
     }
 
     private func condfigureGPSDisabledOverlayView() {


### PR DESCRIPTION
Adds mapOverlays aboveRoads instead of aboveLabels so that
<img width="566" alt="Screenshot 2019-06-13 at 09 26 42" src="https://user-images.githubusercontent.com/14075359/59412527-e4e41900-8dbd-11e9-81a4-5aa912225689.png">
becomes 
<img width="566" alt="Screenshot 2019-06-13 at 09 28 04" src="https://user-images.githubusercontent.com/14075359/59412551-f2999e80-8dbd-11e9-8f37-0f59dd608573.png">
