### PR TITLE
Observation mode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ Changelog for Critical Maps iOS
 
 ## [UNRELEASED]
 
-- Add Dynamic Type support
-
 ### Added
+
+- Dynamic Type support
+- Observation Mode
 
 ### Updated
 

--- a/CriticalMass/BlurryOverlayView.swift
+++ b/CriticalMass/BlurryOverlayView.swift
@@ -8,8 +8,46 @@
 
 import UIKit
 
+@IBDesignable
+class RoundedButton: UIButton {
+    override func awakeFromNib() {
+        configureUI()
+    }
+
+    override func prepareForInterfaceBuilder() {
+        configureUI()
+    }
+
+    private func configureUI() {
+        setTitleColor(.black, for: .normal)
+        backgroundColor = .yellow100
+        layer.cornerRadius = 24
+        titleLabel?.font = UIFont.scalableSystemFont(fontSize: 17, weight: .bold)
+        titleLabel?.adjustsFontForContentSizeCategory = true
+    }
+}
+
 class BlurryOverlayView: UIView, IBConstructable {
+    @objc
+    dynamic var gradientBeginColor: UIColor = .black {
+        didSet {
+            updateGradient()
+        }
+    }
+
+    @objc
+    dynamic var gradientEndColor: UIColor = .white {
+        didSet {
+            updateGradient()
+        }
+    }
+
     @IBOutlet private var messageLabel: UILabel!
+    @IBOutlet var titlelabel: UILabel!
+
+    override class var layerClass: AnyClass {
+        return CAGradientLayer.self
+    }
 
     public var message: String? {
         didSet {
@@ -18,5 +56,22 @@ class BlurryOverlayView: UIView, IBConstructable {
             }
             messageLabel.text = text
         }
+    }
+
+    @IBAction func didTapSettingsButton(_: Any) {
+        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+    }
+
+    override func awakeFromNib() {
+        updateGradient()
+    }
+
+    private func updateGradient() {
+        guard let gradientLayer = self.layer as? CAGradientLayer else {
+            return
+        }
+
+//        gradientLayer.colors = [UIColor(red: 249 / 255.0, green: 244 / 255.0, blue: 236 / 255.0, alpha: 1).cgColor, UIColor(red: 250 / 255.0, green: 244 / 255.0, blue: 237 / 255.0, alpha: 0.75).cgColor]
+        gradientLayer.colors = [gradientBeginColor.cgColor, gradientEndColor.cgColor]
     }
 }

--- a/CriticalMass/BlurryOverlayView.swift
+++ b/CriticalMass/BlurryOverlayView.swift
@@ -42,6 +42,8 @@ class BlurryOverlayView: UIView, IBConstructable {
         }
     }
 
+    @IBOutlet var titleLabelTopConstraint: NSLayoutConstraint!
+    @IBOutlet var settingsButton: RoundedButton!
     @IBOutlet private var messageLabel: UILabel!
     @IBOutlet var titlelabel: UILabel!
 
@@ -66,12 +68,18 @@ class BlurryOverlayView: UIView, IBConstructable {
         updateGradient()
     }
 
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if #available(iOS 11.0, *) {
+            titleLabelTopConstraint.constant = 54 + (window?.safeAreaInsets.top ?? 0)
+        }
+    }
+
     private func updateGradient() {
         guard let gradientLayer = self.layer as? CAGradientLayer else {
             return
         }
 
-//        gradientLayer.colors = [UIColor(red: 249 / 255.0, green: 244 / 255.0, blue: 236 / 255.0, alpha: 1).cgColor, UIColor(red: 250 / 255.0, green: 244 / 255.0, blue: 237 / 255.0, alpha: 0.75).cgColor]
         gradientLayer.colors = [gradientBeginColor.cgColor, gradientEndColor.cgColor]
     }
 }

--- a/CriticalMass/BlurryOverlayView.swift
+++ b/CriticalMass/BlurryOverlayView.swift
@@ -42,30 +42,26 @@ class BlurryOverlayView: UIView, IBConstructable {
         }
     }
 
-    @IBOutlet var titleLabelTopConstraint: NSLayoutConstraint!
-    @IBOutlet var settingsButton: RoundedButton!
+    @IBOutlet private var titleLabelTopConstraint: NSLayoutConstraint!
+    @IBOutlet private var settingsButton: RoundedButton!
     @IBOutlet private var messageLabel: UILabel!
-    @IBOutlet var titlelabel: UILabel!
+    @IBOutlet private var titlelabel: UILabel!
 
     override class var layerClass: AnyClass {
         return CAGradientLayer.self
     }
 
-    public var message: String? {
-        didSet {
-            guard let text = message else {
-                return
-            }
-            messageLabel.text = text
-        }
-    }
-
-    @IBAction func didTapSettingsButton(_: Any) {
-        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
-    }
-
     override func awakeFromNib() {
         updateGradient()
+    }
+
+    public func set(title: String, message: String) {
+        titlelabel.text = title
+        messageLabel.text = message
+    }
+
+    @IBAction private func didTapSettingsButton(_: Any) {
+        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
     }
 
     override func didMoveToWindow() {

--- a/CriticalMass/BlurryOverlayView.swift
+++ b/CriticalMass/BlurryOverlayView.swift
@@ -60,8 +60,8 @@ class BlurryOverlayView: UIView, IBConstructable {
         messageLabel.text = message
     }
 
-    @IBAction private func didTapSettingsButton(_: Any) {
-        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+    public func addButtonTarget(_ taget: Any?, action: Selector) {
+        settingsButton.addTarget(taget, action: action, for: .touchUpInside)
     }
 
     override func didMoveToWindow() {

--- a/CriticalMass/BlurryOverlayView.xib
+++ b/CriticalMass/BlurryOverlayView.xib
@@ -20,19 +20,19 @@
                     <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GPS Deactivated" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JA9-Dq-ih8" customClass="NoContentTitleLabel" customModule="CriticalMaps" customModuleProvider="target">
-                            <rect key="frame" x="24" y="110" width="366" height="29"/>
+                            <rect key="frame" x="24" y="54" width="366" height="29"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sorry, you can't see others\nwhen your GPS is disabled.\n\nPlease enable GPS in settings." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uUg-Jx-Okv" customClass="NoContentMessageLabel" customModule="CriticalMaps" customModuleProvider="target">
-                            <rect key="frame" x="24" y="163" width="366" height="42.5"/>
+                            <rect key="frame" x="24" y="107" width="366" height="42.5"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="J3x-0B-uGU" customClass="RoundedButton" customModule="CriticalMaps" customModuleProvider="target">
-                            <rect key="frame" x="122" y="229.5" width="170" height="48"/>
+                            <rect key="frame" x="122" y="173.5" width="170" height="48"/>
                             <rect key="contentStretch" x="0.050000000000000003" y="0.0" width="1" height="1"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="170" id="W4d-sn-Zoo"/>
@@ -50,7 +50,7 @@
                         </button>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="JA9-Dq-ih8" firstAttribute="top" secondItem="MRp-GU-v6l" secondAttribute="top" constant="110" id="8CC-78-Jqw"/>
+                        <constraint firstItem="JA9-Dq-ih8" firstAttribute="top" secondItem="MRp-GU-v6l" secondAttribute="top" constant="54" id="8CC-78-Jqw"/>
                         <constraint firstItem="JA9-Dq-ih8" firstAttribute="leading" secondItem="MRp-GU-v6l" secondAttribute="leading" constant="24" id="I1D-Vr-FfY"/>
                         <constraint firstItem="J3x-0B-uGU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="MRp-GU-v6l" secondAttribute="leading" priority="999" constant="24" id="KSe-Bw-4qW"/>
                         <constraint firstItem="uUg-Jx-Okv" firstAttribute="leading" secondItem="MRp-GU-v6l" secondAttribute="leading" constant="24" id="NMN-3B-HMU"/>
@@ -74,6 +74,8 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
                 <outlet property="messageLabel" destination="uUg-Jx-Okv" id="BBV-x0-P16"/>
+                <outlet property="settingsButton" destination="J3x-0B-uGU" id="9pP-hz-T4G"/>
+                <outlet property="titleLabelTopConstraint" destination="8CC-78-Jqw" id="U2L-5C-zrc"/>
                 <outlet property="titlelabel" destination="JA9-Dq-ih8" id="C06-As-DMU"/>
             </connections>
             <point key="canvasLocation" x="47.826086956521742" y="35.491071428571423"/>

--- a/CriticalMass/BlurryOverlayView.xib
+++ b/CriticalMass/BlurryOverlayView.xib
@@ -16,44 +16,65 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q99-X0-riz">
+                <view opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MRp-GU-v6l">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="DIJ-pq-qqP">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="svf-tf-w0Z">
-                                <rect key="frame" x="40" y="416" width="334" height="64.5"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sorry, you can't see others\nwhen your GPS is disabled.\n\nPlease enable GPS in settings." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fma-gL-be5" customClass="NoContentMessageLabel" customModule="CriticalMaps" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="334" height="64.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                            </stackView>
-                        </subviews>
-                    </view>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GPS Deactivated" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JA9-Dq-ih8" customClass="NoContentTitleLabel" customModule="CriticalMaps" customModuleProvider="target">
+                            <rect key="frame" x="24" y="110" width="366" height="29"/>
+                            <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sorry, you can't see others\nwhen your GPS is disabled.\n\nPlease enable GPS in settings." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uUg-Jx-Okv" customClass="NoContentMessageLabel" customModule="CriticalMaps" customModuleProvider="target">
+                            <rect key="frame" x="24" y="163" width="366" height="42.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="J3x-0B-uGU" customClass="RoundedButton" customModule="CriticalMaps" customModuleProvider="target">
+                            <rect key="frame" x="122" y="229.5" width="170" height="48"/>
+                            <rect key="contentStretch" x="0.050000000000000003" y="0.0" width="1" height="1"/>
+                            <constraints>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="170" id="W4d-sn-Zoo"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="48" id="jaU-Qs-uzk"/>
+                            </constraints>
+                            <state key="normal" title="Open Settings"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornderRadius">
+                                    <integer key="value" value="16"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                            <connections>
+                                <action selector="didTapSettingsButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="Z3z-M1-AEr"/>
+                            </connections>
+                        </button>
+                    </subviews>
                     <constraints>
-                        <constraint firstItem="svf-tf-w0Z" firstAttribute="leading" secondItem="Q99-X0-riz" secondAttribute="leading" constant="40" id="2Tp-Ea-tOc"/>
-                        <constraint firstItem="svf-tf-w0Z" firstAttribute="centerX" secondItem="Q99-X0-riz" secondAttribute="centerX" id="B4G-b7-tbc"/>
-                        <constraint firstItem="svf-tf-w0Z" firstAttribute="centerY" secondItem="Q99-X0-riz" secondAttribute="centerY" id="Hif-if-5HL"/>
-                        <constraint firstAttribute="trailing" secondItem="svf-tf-w0Z" secondAttribute="trailing" constant="40" id="wC7-gm-ODM"/>
+                        <constraint firstItem="JA9-Dq-ih8" firstAttribute="top" secondItem="MRp-GU-v6l" secondAttribute="top" constant="110" id="8CC-78-Jqw"/>
+                        <constraint firstItem="JA9-Dq-ih8" firstAttribute="leading" secondItem="MRp-GU-v6l" secondAttribute="leading" constant="24" id="I1D-Vr-FfY"/>
+                        <constraint firstItem="J3x-0B-uGU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="MRp-GU-v6l" secondAttribute="leading" priority="999" constant="24" id="KSe-Bw-4qW"/>
+                        <constraint firstItem="uUg-Jx-Okv" firstAttribute="leading" secondItem="MRp-GU-v6l" secondAttribute="leading" constant="24" id="NMN-3B-HMU"/>
+                        <constraint firstItem="uUg-Jx-Okv" firstAttribute="top" secondItem="JA9-Dq-ih8" secondAttribute="bottom" constant="24" id="Ol6-2A-cZ0"/>
+                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="J3x-0B-uGU" secondAttribute="bottom" constant="144" id="cRB-sm-UOV"/>
+                        <constraint firstItem="J3x-0B-uGU" firstAttribute="centerX" secondItem="MRp-GU-v6l" secondAttribute="centerX" id="gHP-eq-oAn"/>
+                        <constraint firstAttribute="trailing" secondItem="uUg-Jx-Okv" secondAttribute="trailing" constant="24" id="il5-kK-nX1"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="J3x-0B-uGU" secondAttribute="trailing" priority="999" constant="24" id="tre-wN-a1q"/>
+                        <constraint firstAttribute="trailing" secondItem="JA9-Dq-ih8" secondAttribute="trailing" constant="24" id="xLL-rn-psF"/>
+                        <constraint firstItem="J3x-0B-uGU" firstAttribute="top" secondItem="uUg-Jx-Okv" secondAttribute="bottom" constant="24" id="yKc-Nw-rg6"/>
                     </constraints>
-                    <blurEffect style="light"/>
-                </visualEffectView>
+                </view>
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="Q99-X0-riz" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" constant="34" id="3yt-H7-Unm"/>
-                <constraint firstItem="Q99-X0-riz" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="Mft-S8-VOX"/>
-                <constraint firstItem="Q99-X0-riz" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="-44" id="fdU-m8-BPE"/>
-                <constraint firstItem="Q99-X0-riz" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="zsv-VR-lbo"/>
+                <constraint firstItem="MRp-GU-v6l" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="4gg-6W-hZw"/>
+                <constraint firstItem="MRp-GU-v6l" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="RSP-TD-MKM"/>
+                <constraint firstAttribute="bottom" secondItem="MRp-GU-v6l" secondAttribute="bottom" id="X2Y-M3-2Ws"/>
+                <constraint firstItem="MRp-GU-v6l" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="gL1-nP-jLS"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
-                <outlet property="messageLabel" destination="fma-gL-be5" id="yXs-3E-bw9"/>
+                <outlet property="messageLabel" destination="uUg-Jx-Okv" id="BBV-x0-P16"/>
+                <outlet property="titlelabel" destination="JA9-Dq-ih8" id="C06-As-DMU"/>
             </connections>
             <point key="canvasLocation" x="47.826086956521742" y="35.491071428571423"/>
         </view>

--- a/CriticalMass/BlurryOverlayView.xib
+++ b/CriticalMass/BlurryOverlayView.xib
@@ -44,9 +44,6 @@
                                     <integer key="value" value="16"/>
                                 </userDefinedRuntimeAttribute>
                             </userDefinedRuntimeAttributes>
-                            <connections>
-                                <action selector="didTapSettingsButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="Z3z-M1-AEr"/>
-                            </connections>
                         </button>
                     </subviews>
                     <constraints>

--- a/CriticalMass/Colors.swift
+++ b/CriticalMass/Colors.swift
@@ -59,4 +59,20 @@ extension UIColor {
     static var darkThemeNavigationOverlaySeperatorColor: UIColor {
         return UIColor(white: 57.0 / 255.0, alpha: 1.00)
     }
+
+    static var lightThemeGradientBegin: UIColor {
+        return UIColor(red: 249.0 / 255.0, green: 244.0 / 255.0, blue: 236.0 / 255.0, alpha: 1.00)
+    }
+
+    static var lightThemeGradientEnd: UIColor {
+        return UIColor(red: 250.0 / 255.0, green: 245.0 / 255.0, blue: 237.0 / 255.0, alpha: 0.75)
+    }
+
+    static var darkThemeGradientBegin: UIColor {
+        return UIColor(red: 43.0 / 255.0, green: 45.0 / 255.0, blue: 47.0 / 255.0, alpha: 1.00)
+    }
+
+    static var darkThemeGradientEnd: UIColor {
+        return UIColor(red: 43.0 / 255.0, green: 45.0 / 255.0, blue: 47.0 / 255.0, alpha: 0.75)
+    }
 }

--- a/CriticalMass/LocationManager.swift
+++ b/CriticalMass/LocationManager.swift
@@ -9,21 +9,17 @@ import CoreLocation
 
 class LocationManager: NSObject, CLLocationManagerDelegate, LocationProvider {
     static var accessPermission: LocationProviderPermission {
-        if Preferences.gpsEnabled {
-            switch CLLocationManager.authorizationStatus() {
-            case .authorizedAlways,
-                 .authorizedWhenInUse:
-                return .authorized
-            case .notDetermined:
-                return .unkown
-            case .restricted,
-                 .denied:
-                return .denied
-            @unknown default:
-                assertionFailure()
-                return .denied
-            }
-        } else {
+        switch CLLocationManager.authorizationStatus() {
+        case .authorizedAlways,
+             .authorizedWhenInUse:
+            return .authorized
+        case .notDetermined:
+            return .unkown
+        case .restricted,
+             .denied:
+            return .denied
+        @unknown default:
+            assertionFailure()
             return .denied
         }
     }
@@ -44,7 +40,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate, LocationProvider {
             }
         }
         get {
-            guard type(of: self).accessPermission == .authorized else {
+            guard type(of: self).accessPermission == .authorized, !Preferences.obersavationModeEnabled else {
                 return nil
             }
             return _currentLocation
@@ -95,6 +91,6 @@ class LocationManager: NSObject, CLLocationManagerDelegate, LocationProvider {
     }
 
     func locationManager(_: CLLocationManager, didChangeAuthorization _: CLAuthorizationStatus) {
-        NotificationCenter.default.post(name: Notification.gpsStateChanged, object: type(of: self).accessPermission)
+        NotificationCenter.default.post(name: Notification.observationModeChanged, object: type(of: self).accessPermission)
     }
 }

--- a/CriticalMass/LocationManager.swift
+++ b/CriticalMass/LocationManager.swift
@@ -40,7 +40,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate, LocationProvider {
             }
         }
         get {
-            guard type(of: self).accessPermission == .authorized, !Preferences.obersavationModeEnabled else {
+            guard type(of: self).accessPermission == .authorized, !ObservationModePreferenceStore().isEnabled else {
                 return nil
             }
             return _currentLocation

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -77,13 +77,14 @@ class MapViewController: UIViewController {
             gpsDisabledOverlayView.heightAnchor.constraint(equalTo: view.heightAnchor),
             gpsDisabledOverlayView.widthAnchor.constraint(equalTo: view.widthAnchor),
         ])
+
         updateGPSDisabledOverlayVisibility()
     }
 
     private func configureNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(positionsDidChange(notification:)), name: Notification.positionOthersChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReceiveInitialLocation(notification:)), name: Notification.initialGpsDataReceived, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(updateGPSDisabledOverlayVisibility), name: Notification.gpsStateChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateGPSDisabledOverlayVisibility), name: Notification.observationModeChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Notification.themeDidChange, object: nil)
     }
 
@@ -97,6 +98,9 @@ class MapViewController: UIViewController {
     }
 
     private func display(locations: [String: Location]) {
+        guard LocationManager.accessPermission == .authorized else {
+            return
+        }
         var unmatchedLocations = locations
         var unmatchedAnnotations: [MKAnnotation] = []
         // update existing annotations
@@ -116,7 +120,7 @@ class MapViewController: UIViewController {
     }
 
     @objc func updateGPSDisabledOverlayVisibility() {
-        gpsDisabledOverlayView.isHidden = LocationManager.accessPermission == .authorized
+        gpsDisabledOverlayView.isHidden = LocationManager.accessPermission != .denied
     }
 
     // MARK: Notifications

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -72,6 +72,7 @@ class MapViewController: UIViewController {
     private func condfigureGPSDisabledOverlayView() {
         let gpsDisabledOverlayView = self.gpsDisabledOverlayView
         gpsDisabledOverlayView.set(title: String.mapLayerInfoTitle, message: String.mapLayerInfo)
+        gpsDisabledOverlayView.addButtonTarget(self, action: #selector(didTapGPSDisabledOverlayButton))
         view.addSubview(gpsDisabledOverlayView)
         NSLayoutConstraint.activate([
             gpsDisabledOverlayView.heightAnchor.constraint(equalTo: view.heightAnchor),
@@ -117,6 +118,10 @@ class MapViewController: UIViewController {
 
         // remove annotations that no longer exist
         mapView.removeAnnotations(unmatchedAnnotations)
+    }
+
+    @objc func didTapGPSDisabledOverlayButton() {
+        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
     }
 
     @objc func updateGPSDisabledOverlayVisibility() {

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -71,7 +71,7 @@ class MapViewController: UIViewController {
 
     private func condfigureGPSDisabledOverlayView() {
         let gpsDisabledOverlayView = self.gpsDisabledOverlayView
-        gpsDisabledOverlayView.message = String.mapLayerInfo
+        gpsDisabledOverlayView.set(title: String.mapLayerInfoTitle, message: String.mapLayerInfo)
         view.addSubview(gpsDisabledOverlayView)
         NSLayoutConstraint.activate([
             gpsDisabledOverlayView.heightAnchor.constraint(equalTo: view.heightAnchor),

--- a/CriticalMass/NoContentMessageLabel.swift
+++ b/CriticalMass/NoContentMessageLabel.swift
@@ -34,3 +34,30 @@ class NoContentMessageLabel: UILabel {
         font = UIFont.preferredFont(forTextStyle: .body)
     }
 }
+
+class NoContentTitleLabel: UILabel {
+    @objc
+    dynamic var messageTextColor: UIColor! {
+        willSet { textColor = newValue }
+    }
+
+    init() {
+        super.init(frame: .zero)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configure()
+    }
+
+    private func configure() {
+        textAlignment = .center
+        numberOfLines = 0
+        font = UIFont.scalableSystemFont(fontSize: 24, weight: .bold)
+    }
+}

--- a/CriticalMass/Notification+Static.swift
+++ b/CriticalMass/Notification+Static.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Notification {
     static let themeDidChange = Notification.Name(rawValue: "themeDidChange")
     static let initialGpsDataReceived = Notification.Name(rawValue: "initialGpsDataReceived")
-    static let gpsStateChanged = Notification.Name(rawValue: "gpsStateChanged")
+    static let observationModeChanged = Notification.Name(rawValue: "observationModeChanged")
     static let positionOthersChanged = Notification.Name(rawValue: "positionOthersChanged")
     static let chatMessagesReceived = Notification.Name(rawValue: "chatMessagesReceived")
 }

--- a/CriticalMass/Preferences.swift
+++ b/CriticalMass/Preferences.swift
@@ -7,17 +7,33 @@
 
 import Foundation
 
-class Preferences {
-    static var obersavationModeEnabled: Bool {
-        get {
-            return UserDefaults.standard.bool(forKey: #function)
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: #function)
-            NotificationCenter.default.post(name: Notification.observationModeChanged, object: newValue)
-        }
+class ObservationModePreferenceStore: Switchable {
+    private let defaultsKey = "observationMode"
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
     }
 
+    func save(_ isEnabled: Bool) {
+        defaults.set(isEnabled, forKey: defaultsKey)
+        NotificationCenter.default.post(name: Notification.observationModeChanged, object: isEnabled)
+    }
+
+    func load() -> Bool? {
+        return defaults.bool(forKey: defaultsKey)
+    }
+
+    var isEnabled: Bool {
+        get {
+            return load() ?? false
+        } set {
+            save(newValue)
+        }
+    }
+}
+
+class Preferences {
     static var lastMessageReadTimeInterval: Double {
         get {
             return UserDefaults.standard.double(forKey: #function)

--- a/CriticalMass/Preferences.swift
+++ b/CriticalMass/Preferences.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 class Preferences {
-    static var gpsEnabled: Bool {
+    static var obersavationModeEnabled: Bool {
         get {
             return UserDefaults.standard.bool(forKey: #function)
         }
         set {
             UserDefaults.standard.set(newValue, forKey: #function)
-            NotificationCenter.default.post(name: Notification.gpsStateChanged, object: newValue)
+            NotificationCenter.default.post(name: Notification.observationModeChanged, object: newValue)
         }
     }
 

--- a/CriticalMass/Preferences.swift
+++ b/CriticalMass/Preferences.swift
@@ -15,12 +15,12 @@ class ObservationModePreferenceStore: Switchable {
         self.defaults = defaults
     }
 
-    func save(_ isEnabled: Bool) {
+    private func save(_ isEnabled: Bool) {
         defaults.set(isEnabled, forKey: defaultsKey)
         NotificationCenter.default.post(name: Notification.observationModeChanged, object: isEnabled)
     }
 
-    func load() -> Bool? {
+    private func load() -> Bool? {
         return defaults.bool(forKey: defaultsKey)
     }
 

--- a/CriticalMass/SettingsGithubTableViewCellTableViewCell.xib
+++ b/CriticalMass/SettingsGithubTableViewCellTableViewCell.xib
@@ -19,7 +19,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="GithubBanner" translatesAutoresizingMaskIntoConstraints="NO" id="VXc-gu-JtL">
-                        <rect key="frame" x="16" y="16" width="368" height="193.50000000000006"/>
+                        <rect key="frame" x="16" y="16" width="368" height="193.5"/>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="b5G-Gd-zcX">
                         <rect key="frame" x="36" y="36" width="328" height="153.5"/>
@@ -37,7 +37,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="yjg-8l-o9D">
-                                <rect key="frame" x="0.0" y="135.5" width="167" height="18"/>
+                                <rect key="frame" x="0.0" y="135.5" width="165" height="18"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="PROJEKT ANSEHEN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2xr-Tp-a5U">
                                         <rect key="frame" x="0.0" y="0.0" width="139" height="18"/>
@@ -46,7 +46,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ArrowButton" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MCh-Zj-FA7">
-                                        <rect key="frame" x="149" y="0.0" width="18" height="18"/>
+                                        <rect key="frame" x="149" y="0.0" width="16" height="18"/>
                                     </imageView>
                                 </subviews>
                             </stackView>

--- a/CriticalMass/SettingsSection.swift
+++ b/CriticalMass/SettingsSection.swift
@@ -55,7 +55,7 @@ enum Section: Int, CaseIterable {
         case .preferences:
             return [
                 Model(title: String.themeLocalizedString, action: .switch(ThemeController.self)),
-                Model(title: String.gpsLocalizedString, subtitle: "If you don’t take part yourself, but want to follow the Critical Mass.", action: .switch(ObservationModePreferenceStore.self)),
+                Model(title: String.obversationModeTitle, subtitle: String.obversationModeDetail, action: .switch(ObservationModePreferenceStore.self)),
             ]
         case .github:
             return [Model(action: .open(url: Constants.criticalMapsiOSGitHubEndpoint))]

--- a/CriticalMass/SettingsSection.swift
+++ b/CriticalMass/SettingsSection.swift
@@ -55,7 +55,7 @@ enum Section: Int, CaseIterable {
         case .preferences:
             return [
                 Model(title: String.themeLocalizedString, action: .switch(ThemeController.self)),
-                Model(title: String.gpsLocalizedString, subtitle: "Hello World", action: .switch(ObservationModePreferenceStore.self)),
+                Model(title: String.gpsLocalizedString, subtitle: "If you don’t take part yourself, but want to follow the Critical Mass.", action: .switch(ObservationModePreferenceStore.self)),
             ]
         case .github:
             return [Model(action: .open(url: Constants.criticalMapsiOSGitHubEndpoint))]

--- a/CriticalMass/SettingsSection.swift
+++ b/CriticalMass/SettingsSection.swift
@@ -8,12 +8,6 @@
 
 import Foundation
 
-extension Hashable where Self: CaseIterable {
-    var index: Self.AllCases.Index {
-        return type(of: self).allCases.firstIndex(of: self)!
-    }
-}
-
 enum Section: Int, CaseIterable {
     case preferences
     case github
@@ -35,7 +29,7 @@ enum Section: Int, CaseIterable {
         return models.count
     }
 
-    var secionTitle: String? {
+    var title: String? {
         switch self {
         case .preferences,
              .github:
@@ -60,8 +54,8 @@ enum Section: Int, CaseIterable {
         switch self {
         case .preferences:
             return [
-                Model(title: String.themeLocalizedString, action: .none),
-                Model(title: String.gpsLocalizedString, subtitle: "Hello World", action: .none),
+                Model(title: String.themeLocalizedString, action: .switch(ThemeController.self)),
+                Model(title: String.gpsLocalizedString, subtitle: "Hello World", action: .switch(ObservationModePreferenceStore.self)),
             ]
         case .github:
             return [Model(action: .open(url: Constants.criticalMapsiOSGitHubEndpoint))]
@@ -74,6 +68,6 @@ enum Section: Int, CaseIterable {
 
     enum Action {
         case open(url: URL)
-        case none
+        case `switch`(_ switchtable: Switchable.Type)
     }
 }

--- a/CriticalMass/SettingsSection.swift
+++ b/CriticalMass/SettingsSection.swift
@@ -21,7 +21,14 @@ enum Section: Int, CaseIterable {
 
     struct Model {
         var title: String?
+        var subtitle: String?
         var action: Action
+
+        init(title: String? = nil, subtitle: String? = nil, action: Action) {
+            self.title = title
+            self.subtitle = subtitle
+            self.action = action
+        }
     }
 
     var numberOfRows: Int {
@@ -53,11 +60,11 @@ enum Section: Int, CaseIterable {
         switch self {
         case .preferences:
             return [
-                Model(title: String.gpsLocalizedString, action: .none),
                 Model(title: String.themeLocalizedString, action: .none),
+                Model(title: String.gpsLocalizedString, subtitle: "Hello World", action: .none),
             ]
         case .github:
-            return [Model(title: nil, action: .open(url: Constants.criticalMapsiOSGitHubEndpoint))]
+            return [Model(action: .open(url: Constants.criticalMapsiOSGitHubEndpoint))]
         case .info:
             return [Model(title: String.settingsWebsite, action: .open(url: Constants.criticalMapsWebsite)),
                     Model(title: String.settingsTwitter, action: .open(url: Constants.criticalMapsTwitterPage)),

--- a/CriticalMass/SettingsSwitchTableViewCell.swift
+++ b/CriticalMass/SettingsSwitchTableViewCell.swift
@@ -7,18 +7,16 @@
 
 import UIKit
 
-protocol SettingsSwitchCellConfigurable {
-    func configure(isOn: Bool, handler: SettingsSwitchHandler?)
+protocol Switchable {
+    var isEnabled: Bool { get set }
 }
 
-typealias SettingsSwitchHandler = (UISwitch) -> Void
-
-class SettingsSwitchTableViewCell: UITableViewCell, SettingsSwitchCellConfigurable, IBConstructable {
+class SettingsSwitchTableViewCell: UITableViewCell, IBConstructable {
     private let switchControl = UISwitch()
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var subtitleLabel: UILabel!
 
-    private var switchActionHandler: SettingsSwitchHandler?
+    private var switchable: Switchable?
 
     override var textLabel: UILabel? {
         return titleLabel
@@ -29,9 +27,9 @@ class SettingsSwitchTableViewCell: UITableViewCell, SettingsSwitchCellConfigurab
         return subtitleLabel
     }
 
-    func configure(isOn: Bool, handler: SettingsSwitchHandler?) {
-        switchControl.isOn = isOn
-        switchActionHandler = handler
+    func configure(switchable: Switchable) {
+        switchControl.isOn = switchable.isEnabled
+        self.switchable = switchable
     }
 
     override func awakeFromNib() {
@@ -43,7 +41,7 @@ class SettingsSwitchTableViewCell: UITableViewCell, SettingsSwitchCellConfigurab
 
     @objc
     func switchControlAction(_ sender: UISwitch) {
-        switchActionHandler?(sender)
+        switchable?.isEnabled = sender.isOn
     }
 
     override func prepareForReuse() {

--- a/CriticalMass/SettingsSwitchTableViewCell.swift
+++ b/CriticalMass/SettingsSwitchTableViewCell.swift
@@ -12,6 +12,20 @@ protocol Switchable {
 }
 
 class SettingsSwitchTableViewCell: UITableViewCell, IBConstructable {
+    @objc
+    dynamic var titleColor: UIColor? {
+        willSet {
+            titleLabel.textColor = newValue
+        }
+    }
+
+    @objc
+    dynamic var subtitleColor: UIColor? {
+        willSet {
+            subtitleLabel.textColor = newValue
+        }
+    }
+
     private let switchControl = UISwitch()
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var subtitleLabel: UILabel!

--- a/CriticalMass/SettingsSwitchTableViewCell.swift
+++ b/CriticalMass/SettingsSwitchTableViewCell.swift
@@ -16,11 +16,17 @@ typealias SettingsSwitchHandler = (UISwitch) -> Void
 class SettingsSwitchTableViewCell: UITableViewCell, SettingsSwitchCellConfigurable, IBConstructable {
     private let switchControl = UISwitch()
     @IBOutlet var titleLabel: UILabel!
+    @IBOutlet var subtitleLabel: UILabel!
 
     private var switchActionHandler: SettingsSwitchHandler?
 
     override var textLabel: UILabel? {
         return titleLabel
+    }
+
+    override var detailTextLabel: UILabel? {
+        subtitleLabel.isHidden = false
+        return subtitleLabel
     }
 
     func configure(isOn: Bool, handler: SettingsSwitchHandler?) {
@@ -30,6 +36,7 @@ class SettingsSwitchTableViewCell: UITableViewCell, SettingsSwitchCellConfigurab
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        subtitleLabel.isHidden = true
         accessoryView = switchControl
         switchControl.addTarget(self, action: #selector(switchControlAction(_:)), for: .valueChanged)
     }
@@ -37,5 +44,10 @@ class SettingsSwitchTableViewCell: UITableViewCell, SettingsSwitchCellConfigurab
     @objc
     func switchControlAction(_ sender: UISwitch) {
         switchActionHandler?(sender)
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        subtitleLabel.isHidden = true
     }
 }

--- a/CriticalMass/SettingsSwitchTableViewCell.xib
+++ b/CriticalMass/SettingsSwitchTableViewCell.xib
@@ -11,34 +11,46 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="68" id="KGk-i7-Jjw" customClass="SettingsSwitchTableViewCell" customModule="CriticalMaps" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="114" id="KGk-i7-Jjw" customClass="SettingsSwitchTableViewCell" customModule="CriticalMaps" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="102"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="55.5"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="101.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EDT-Sy-r2Q">
-                        <rect key="frame" x="16" y="0.0" width="288" height="56.5"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ljO-QZ-mTL">
+                        <rect key="frame" x="16" y="0.0" width="288" height="101.5"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EDT-Sy-r2Q">
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="83.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pju-oQ-CFc">
+                                <rect key="frame" x="0.0" y="83.5" width="288" height="18"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="56" id="5tY-XT-Y8T"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="56" id="Ghn-U2-KdS"/>
                         </constraints>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailingMargin" secondItem="EDT-Sy-r2Q" secondAttribute="trailing" id="FrG-xs-Usn"/>
-                    <constraint firstItem="EDT-Sy-r2Q" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="My2-52-YwF"/>
-                    <constraint firstAttribute="bottom" secondItem="EDT-Sy-r2Q" secondAttribute="bottom" id="lC3-FR-vNQ"/>
-                    <constraint firstItem="EDT-Sy-r2Q" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="pTs-ax-D7q"/>
+                    <constraint firstItem="ljO-QZ-mTL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="3FC-aa-vyb"/>
+                    <constraint firstAttribute="bottom" secondItem="ljO-QZ-mTL" secondAttribute="bottom" id="Qvd-D2-1Nz"/>
+                    <constraint firstItem="ljO-QZ-mTL" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="TCw-cv-Huh"/>
+                    <constraint firstAttribute="trailing" secondItem="ljO-QZ-mTL" secondAttribute="trailing" constant="16" id="h9f-WH-Hay"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
+                <outlet property="subtitleLabel" destination="pju-oQ-CFc" id="qA1-vy-Fmk"/>
                 <outlet property="titleLabel" destination="EDT-Sy-r2Q" id="ZZi-T1-lN0"/>
             </connections>
-            <point key="canvasLocation" x="52.799999999999997" y="53.973013493253376"/>
+            <point key="canvasLocation" x="52.799999999999997" y="74.662668665667169"/>
         </tableViewCell>
     </objects>
 </document>

--- a/CriticalMass/SettingsSwitchTableViewCell.xib
+++ b/CriticalMass/SettingsSwitchTableViewCell.xib
@@ -18,17 +18,17 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="101.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ljO-QZ-mTL">
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="ljO-QZ-mTL">
                         <rect key="frame" x="16" y="0.0" width="288" height="101.5"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EDT-Sy-r2Q">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="83.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Observation Mode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EDT-Sy-r2Q">
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="39.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pju-oQ-CFc">
-                                <rect key="frame" x="0.0" y="83.5" width="288" height="18"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you don’t take part yourself, but want to follow the Critical Mass." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pju-oQ-CFc">
+                                <rect key="frame" x="0.0" y="39.5" width="288" height="62"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/CriticalMass/SettingsSwitchTableViewCell.xib
+++ b/CriticalMass/SettingsSwitchTableViewCell.xib
@@ -19,16 +19,16 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="ljO-QZ-mTL">
-                        <rect key="frame" x="16" y="0.0" width="288" height="101.5"/>
+                        <rect key="frame" x="16" y="16" width="288" height="69.5"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Observation Mode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EDT-Sy-r2Q">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="39.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="27"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you don’t take part yourself, but want to follow the Critical Mass." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pju-oQ-CFc">
-                                <rect key="frame" x="0.0" y="39.5" width="288" height="62"/>
+                                <rect key="frame" x="0.0" y="27" width="288" height="42.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -41,8 +41,8 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="ljO-QZ-mTL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="3FC-aa-vyb"/>
-                    <constraint firstAttribute="bottom" secondItem="ljO-QZ-mTL" secondAttribute="bottom" id="Qvd-D2-1Nz"/>
-                    <constraint firstItem="ljO-QZ-mTL" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="TCw-cv-Huh"/>
+                    <constraint firstAttribute="bottom" secondItem="ljO-QZ-mTL" secondAttribute="bottom" constant="16" id="Qvd-D2-1Nz"/>
+                    <constraint firstItem="ljO-QZ-mTL" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="TCw-cv-Huh"/>
                     <constraint firstAttribute="trailing" secondItem="ljO-QZ-mTL" secondAttribute="trailing" constant="16" id="h9f-WH-Hay"/>
                 </constraints>
             </tableViewCellContentView>

--- a/CriticalMass/SettingsViewController.swift
+++ b/CriticalMass/SettingsViewController.swift
@@ -54,9 +54,7 @@ class SettingsViewController: UITableViewController {
 
     // MARK: Actions
 
-    @IBAction func gpsCellAction(_ sender: UISwitch) {
-        Preferences.gpsEnabled = sender.isOn
-    }
+    @IBAction func gpsCellAction(_: UISwitch) {}
 
     @IBAction func darkModeCellAction(_ sender: UISwitch) {
         let theme: Theme = sender.isOn ? .dark : .light
@@ -93,6 +91,7 @@ class SettingsViewController: UITableViewController {
         let section = Section.allCases[indexPath.section]
         let cell = settingsCell(for: section, at: indexPath)
         cell.textLabel?.text = section.models[indexPath.row].title
+        cell.detailTextLabel?.text = section.models[indexPath.row].subtitle
         return cell
     }
 
@@ -125,7 +124,7 @@ extension SettingsViewController {
             }
             let model = section.models[indexPath.row]
             if model.title == String.gpsLocalizedString {
-                let isGPSEnabled = Preferences.gpsEnabled
+                let isGPSEnabled = true
                 let gpsHandler: SettingsSwitchHandler = { [unowned self] settingsSwitch in
                     self.gpsCellAction(settingsSwitch)
                 }

--- a/CriticalMass/SettingsViewController.swift
+++ b/CriticalMass/SettingsViewController.swift
@@ -52,28 +52,18 @@ class SettingsViewController: UITableViewController {
         }
     }
 
-    // MARK: Actions
-
-    @IBAction func gpsCellAction(_: UISwitch) {}
-
-    @IBAction func darkModeCellAction(_ sender: UISwitch) {
-        let theme: Theme = sender.isOn ? .dark : .light
-        themeController.changeTheme(to: theme)
-        themeController.applyTheme()
-    }
-
     override func numberOfSections(in _: UITableView) -> Int {
         return Section.allCases.count
     }
 
     override func tableView(_: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = tableView.dequeueReusableHeaderFooterView(ofType: SettingsTableSectionHeader.self)
-        header.titleLabel.text = Section.allCases[section].secionTitle
+        header.titleLabel.text = Section.allCases[section].title
         return header
     }
 
     override func tableView(_: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard section == Section.info.index else {
+        guard Section.allCases[section].title != nil else {
             return 0.0
         }
         return 42.0
@@ -89,9 +79,8 @@ class SettingsViewController: UITableViewController {
 
     override func tableView(_: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let section = Section.allCases[indexPath.section]
-        let cell = settingsCell(for: section, at: indexPath)
-        cell.textLabel?.text = section.models[indexPath.row].title
-        cell.detailTextLabel?.text = section.models[indexPath.row].subtitle
+        let cell = tableView.dequeueReusableCell(withIdentifier: String(describing: section.cellClass), for: indexPath)
+        configure(cell, for: section.models[indexPath.row])
         return cell
     }
 
@@ -102,48 +91,31 @@ class SettingsViewController: UITableViewController {
         let acttion = section.models[indexPath.row].action
 
         switch acttion {
-        case .none:
-            return
         case let .open(url: url):
             let application = UIApplication.shared
             guard application.canOpenURL(url) else {
                 return
             }
             application.open(url, options: [:], completionHandler: nil)
+        case .switch:
+            break
         }
     }
 }
 
 extension SettingsViewController {
-    fileprivate func settingsCell(for section: Section, at indexPath: IndexPath) -> UITableViewCell {
-        var cell: UITableViewCell
-        switch section {
-        case .preferences:
-            guard let switchCell = tableView.dequeueReusableCell(withIdentifier: String(describing: section.cellClass), for: indexPath) as? SettingsSwitchTableViewCell else {
-                fatalError("Should be a SettingsSwitchCell")
-            }
-            let model = section.models[indexPath.row]
-            if model.title == String.gpsLocalizedString {
-                let isGPSEnabled = true
-                let gpsHandler: SettingsSwitchHandler = { [unowned self] settingsSwitch in
-                    self.gpsCellAction(settingsSwitch)
-                }
-                switchCell.configure(isOn: isGPSEnabled, handler: gpsHandler)
-                cell = switchCell
-            } else if model.title == String.themeLocalizedString {
-                let isNightModeEnabled = themeController.currentTheme == .dark ? true : false
-                let nightModeHandler: (UISwitch) -> Void = { [unowned self] settingsSwitch in
-                    self.darkModeCellAction(settingsSwitch)
-                }
-                switchCell.configure(isOn: isNightModeEnabled, handler: nightModeHandler)
-                cell = switchCell
+    fileprivate func configure(_ cell: UITableViewCell, for model: Section.Model) {
+        if let switchCell = cell as? SettingsSwitchTableViewCell,
+            case let .switch(switchableType) = model.action {
+            if switchableType == ObservationModePreferenceStore.self {
+                switchCell.configure(switchable: ObservationModePreferenceStore())
+            } else if switchableType == ThemeController.self {
+                switchCell.configure(switchable: themeController)
             } else {
-                print("Title not found")
+                assertionFailure("Switchable not found")
             }
-            cell = switchCell
-        case .info, .github:
-            cell = tableView.dequeueReusableCell(withIdentifier: String(describing: section.cellClass), for: indexPath)
         }
-        return cell
+        cell.textLabel?.text = model.title
+        cell.detailTextLabel?.text = model.subtitle
     }
 }

--- a/CriticalMass/SettingsViewController.swift
+++ b/CriticalMass/SettingsViewController.swift
@@ -88,9 +88,9 @@ class SettingsViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: true)
 
         let section = Section.allCases[indexPath.section]
-        let acttion = section.models[indexPath.row].action
+        let action = section.models[indexPath.row].action
 
-        switch acttion {
+        switch action {
         case let .open(url: url):
             let application = UIApplication.shared
             guard application.canOpenURL(url) else {

--- a/CriticalMass/String+LocalizedStrings.swift
+++ b/CriticalMass/String+LocalizedStrings.swift
@@ -11,11 +11,12 @@ import Foundation
 extension String {
     static let twitterNoData = NSLocalizedString("twitter.noData", comment: "")
     static let rulesTitle = NSLocalizedString("rules.title", comment: "")
-    static let gpsLocalizedString = NSLocalizedString("GPS", comment: "")
     static let error = NSLocalizedString("error", comment: "")
     static let closeButtonLabel = NSLocalizedString("close.button.label", comment: "")
     // Settings
     static let themeLocalizedString = NSLocalizedString("settings.theme", comment: "")
+    static let obversationModeTitle = NSLocalizedString("settings.observationmode.title", comment: "")
+    static let obversationModeDetail = NSLocalizedString("settings.observationmode.detail", comment: "")
     static let settingsTitle = NSLocalizedString("settings.title", comment: "")
     static let settingsSectionInfo = NSLocalizedString("settings.section.info", comment: "")
     static let settingsWebsite = NSLocalizedString("settings.website", comment: "")
@@ -32,5 +33,6 @@ extension String {
     static let chatSendError = NSLocalizedString("chat.send.error", comment: "")
     // Map
     static let mapLayerInfo = NSLocalizedString("map.layer.info", comment: "")
+    static let mapLayerInfoTitle = NSLocalizedString("map.layer.info.title", comment: "")
     static let mapTitle = NSLocalizedString("map.title", comment: "")
 }

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -50,14 +50,15 @@ class ThemeController {
     }
 
     private func styleSettingsComponents(with theme: ThemeDefining) {
-        UILabel.appearance(whenContainedInInstancesOf: [UITableViewHeaderFooterView.self]).backgroundColor = theme.backgroundColor
-        UILabel.appearance(whenContainedInInstancesOf: [UITableViewHeaderFooterView.self]).textColor = theme.titleTextColor
         // UISwitch
         UISwitch.appearance().onTintColor = theme.switchTintColor
         // Custom Views
         SettingsFooterView.appearance().versionTextColor = theme.titleTextColor
         SettingsFooterView.appearance().buildTextColor = theme.titleTextColor
-        SettingsGithubTableViewCellTableViewCell.appearance().arrowTintColor = theme.backgroundColor
+        SettingsGithubTableViewCellTableViewCell.appearance().arrowTintColor = .settingsOpenSourceForeground
+        UILabel.appearance(whenContainedInInstancesOf: [SettingsInfoTableViewCell.self]).textColor = theme.titleTextColor
+        SettingsSwitchTableViewCell.appearance().titleColor = theme.titleTextColor
+        SettingsSwitchTableViewCell.appearance().subtitleColor = theme.secondaryTitleTextColor
     }
 
     private func styleNavigationOverlayComponents(with theme: ThemeDefining) {
@@ -87,6 +88,7 @@ class ThemeController {
         // UIToolBar
         UIToolbar.appearance().barTintColor = theme.toolBarBackgroundColor
         UILabel.appearance(whenContainedInInstancesOf: [TweetTableViewCell.self]).textColor = theme.titleTextColor
+        UILabel.appearance(whenContainedInInstancesOf: [ChatNavigationButton.self]).textColor = .white
     }
 
     private func styleGlobalComponents(with theme: ThemeDefining) {
@@ -114,8 +116,8 @@ class ThemeController {
         UITextView.appearance().textColor = theme.titleTextColor
         // UILabel
         UITableView.appearance().tintColor = theme.titleTextColor
-        UILabel.appearance(whenContainedInInstancesOf: [ChatNavigationButton.self]).textColor = .white
-        UILabel.appearance(whenContainedInInstancesOf: [UITableViewCell.self]).textColor = theme.titleTextColor
+        UILabel.appearance(whenContainedInInstancesOf: [UITableViewHeaderFooterView.self]).backgroundColor = theme.backgroundColor
+        UILabel.appearance(whenContainedInInstancesOf: [UITableViewHeaderFooterView.self]).textColor = theme.titleTextColor
     }
 
     private func styleBlurredOverlayComponents(with theme: ThemeDefining) {

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -58,7 +58,7 @@ class ThemeController {
         SettingsGithubTableViewCellTableViewCell.appearance().arrowTintColor = .settingsOpenSourceForeground
         UILabel.appearance(whenContainedInInstancesOf: [SettingsInfoTableViewCell.self]).textColor = theme.titleTextColor
         SettingsSwitchTableViewCell.appearance().titleColor = theme.titleTextColor
-        SettingsSwitchTableViewCell.appearance().subtitleColor = theme.secondaryTitleTextColor
+        SettingsSwitchTableViewCell.appearance().subtitleColor = theme.thirdTitleTextColor
     }
 
     private func styleNavigationOverlayComponents(with theme: ThemeDefining) {

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -37,7 +37,9 @@ class ThemeController {
         styleRulesComponents(with: theme)
         styleSettingsComponents(with: theme)
         styleNavigationOverlayComponents(with: theme)
+        styleBlurredOverlayComponents(with: theme)
         NoContentMessageLabel.appearance().messageTextColor = theme.titleTextColor
+        NoContentTitleLabel.appearance().messageTextColor = theme.titleTextColor
         NotificationCenter.default.post(name: Notification.themeDidChange, object: nil) // trigger map tileRenderer update
         UIApplication.shared.refreshAppearance(animated: false)
     }
@@ -114,5 +116,10 @@ class ThemeController {
         UITableView.appearance().tintColor = theme.titleTextColor
         UILabel.appearance(whenContainedInInstancesOf: [ChatNavigationButton.self]).textColor = .white
         UILabel.appearance(whenContainedInInstancesOf: [UITableViewCell.self]).textColor = theme.titleTextColor
+    }
+    
+    private func styleBlurredOverlayComponents(with theme: ThemeDefining) {
+        BlurryOverlayView.appearance().gradientBeginColor = theme.gradientBeginColor
+        BlurryOverlayView.appearance().gradientEndColor = theme.gradientEndColor
     }
 }

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -133,7 +133,10 @@ extension ThemeController: Switchable {
         }
         set {
             changeTheme(to: newValue ? .dark : .light)
-            applyTheme()
+            // This is a workaround to wait for the switch animation to finish before updating the UI
+            DispatchQueue.main.async {
+                self.applyTheme()
+            }
         }
     }
 }

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -117,7 +117,7 @@ class ThemeController {
         UILabel.appearance(whenContainedInInstancesOf: [ChatNavigationButton.self]).textColor = .white
         UILabel.appearance(whenContainedInInstancesOf: [UITableViewCell.self]).textColor = theme.titleTextColor
     }
-    
+
     private func styleBlurredOverlayComponents(with theme: ThemeDefining) {
         BlurryOverlayView.appearance().gradientBeginColor = theme.gradientBeginColor
         BlurryOverlayView.appearance().gradientEndColor = theme.gradientEndColor

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -123,3 +123,15 @@ class ThemeController {
         BlurryOverlayView.appearance().gradientEndColor = theme.gradientEndColor
     }
 }
+
+extension ThemeController: Switchable {
+    var isEnabled: Bool {
+        get {
+            return currentTheme == .dark
+        }
+        set {
+            changeTheme(to: newValue ? .dark : .light)
+            applyTheme()
+        }
+    }
+}

--- a/CriticalMass/ThemeDefining.swift
+++ b/CriticalMass/ThemeDefining.swift
@@ -26,6 +26,8 @@ protocol ThemeDefining {
     var toolBarBackgroundColor: UIColor { get }
     var navigationOverlayBackgroundColor: UIColor { get }
     var statusBarStyle: UIStatusBarStyle { get }
+    var gradientBeginColor: UIColor { get }
+    var gradientEndColor: UIColor { get }
 }
 
 struct LightTheme: ThemeDefining {
@@ -92,6 +94,14 @@ struct LightTheme: ThemeDefining {
     var statusBarStyle: UIStatusBarStyle {
         return .default
     }
+
+    var gradientBeginColor: UIColor {
+        return .lightThemeGradientBegin
+    }
+
+    var gradientEndColor: UIColor {
+        return .lightThemeGradientEnd
+    }
 }
 
 struct DarkTheme: ThemeDefining {
@@ -157,5 +167,13 @@ struct DarkTheme: ThemeDefining {
 
     var statusBarStyle: UIStatusBarStyle {
         return .lightContent
+    }
+
+    var gradientBeginColor: UIColor {
+        return .darkThemeGradientBegin
+    }
+
+    var gradientEndColor: UIColor {
+        return .darkThemeGradientEnd
     }
 }

--- a/CriticalMass/de.lproj/Localizable.strings
+++ b/CriticalMass/de.lproj/Localizable.strings
@@ -18,7 +18,10 @@
 "error" = "Fehler";
 
 /* No comment provided by engineer. */
-"map.layer.info" = "Sorry, du kannst die anderen nicht sehen,\nwenn dein GPS ausgeschalten ist.\n\nBitte aktiviere GPS in den Einstellungen.";
+"map.layer.info.title" = "GPS deaktiviert";
+
+/* No comment provided by engineer. */
+"map.layer.info" = "Critical Maps muss dein GPS verwenden, um die Karte anderen aktiven Benutzer anzuzeigen";
 
 /* No comment provided by engineer. */
 "map.locationButton.label" = "Ortung";
@@ -87,7 +90,10 @@
 "settings.donate" = "Helfe unseren Server zu finanzieren";
 
 /* No comment provided by engineer. */
-"settings.enableGps" = "Teile deinen Standort mit anderen";
+"settings.observationmode.title" = "Beobachtungsmodus";
+
+/* No comment provided by engineer. */
+"settings.observationmode.detail" = "Wenn du nicht selbst teilnimmst, aber trotzdem der Critical Mass folgen möchtest.";
 
 /* No comment provided by engineer. */
 "settings.facebook" = "Facebook";

--- a/CriticalMass/en.lproj/Localizable.strings
+++ b/CriticalMass/en.lproj/Localizable.strings
@@ -18,7 +18,10 @@
 "error" = "Error";
 
 /* No comment provided by engineer. */
-"map.layer.info" = "Sorry, you can't see others\nwhen your GPS is disabled.\n\nPlease enable GPS in settings.";
+"map.layer.info.title" = "GPS deactivated";
+
+/* No comment provided by engineer. */
+"map.layer.info" = "Critical Maps needs to use your GPS to show the map with other active user";
 
 /* No comment provided by engineer. */
 "map.locationButton.label" = "locating";
@@ -87,7 +90,10 @@
 "settings.donate" = "Help finacing our tracking server";
 
 /* No comment provided by engineer. */
-"settings.enableGps" = "Share your location with others";
+"settings.observationmode.title" = "Observation Mode";
+
+/* No comment provided by engineer. */
+"settings.observationmode.detail" = "If you don’t take part yourself, but want to follow the Critical Mass.";
 
 /* No comment provided by engineer. */
 "settings.facebook" = "Facebook";

--- a/CriticalMass/fr.lproj/Localizable.strings
+++ b/CriticalMass/fr.lproj/Localizable.strings
@@ -17,7 +17,10 @@
 "error" = "Erreur";
 
 /* No comment provided by engineer. */
-"map.layer.info" = "Désolé, tu ne peux pas voir les autres \nsi ton GPS est désactivé.\n\nTu peux activer ton GPS dans les réglages.";
+"map.layer.info.title" = "GPS désactivé";
+
+/* No comment provided by engineer. */
+"map.layer.info" = "Critical Maps doit utiliser votre GPS pour montrer la carte avec d'autres utilisateurs actifs";
 
 /* No comment provided by engineer. */
 "map.locationButton.label" = "localisation";
@@ -99,7 +102,10 @@
 "settings.facebook" = "Facebook";
 
 /* No comment provided by engineer. */
-"settings.gpsSettings" = "Réglages GPS";
+"settings.observationmode.title" = "Mode d'observation";
+
+/* No comment provided by engineer. */
+"settings.observationmode.detail" = "Si vous ne participez pas vous-même, mais que vous voulez suivre la Critical Mass.";
 
 /* No comment provided by engineer. */
 "settings.kniggeImages" = "Rules images";

--- a/CriticalMass/it.lproj/Localizable.strings
+++ b/CriticalMass/it.lproj/Localizable.strings
@@ -18,7 +18,10 @@
 "error" = "Errore";
 
 /* No comment provided by engineer. */
-"map.layer.info" = "Non è possibile vedere gli altri\nquando il GPS è disabilitato.\n\nVai su \"Impostazioni\" per attivarlo.";
+"map.layer.info.title" = "GPS disattivato";
+
+/* No comment provided by engineer. */
+"map.layer.info" = "Critical Maps deve utilizzare il GPS per mostrare la mappa con altri utenti attivi";
 
 /* No comment provided by engineer. */
 "map.locationButton.label" = "posizionamento";
@@ -87,7 +90,10 @@
 "settings.donate" = "Supporta i costi del server";
 
 /* No comment provided by engineer. */
-"settings.enableGps" = "Abilita il GPS";
+"settings.observationmode.title" = "Modalità di osservazione";
+
+/* No comment provided by engineer. */
+"settings.observationmode.detail" = "Se non partecipi da solo, ma vuoi seguire la Critical Mass.";
 
 /* No comment provided by engineer. */
 "settings.facebook" = "Facebook";

--- a/CriticalMassTests/ThemeControllerTests.swift
+++ b/CriticalMassTests/ThemeControllerTests.swift
@@ -368,17 +368,6 @@ class ThemeControllerTests: XCTestCase {
         XCTAssertEqual(color, UIColor.white)
     }
 
-    func testUILabelTextTextColorShouldChangeToTitleTextColorWhenContainedInUITableViewCellAndNightModeWasSelected() {
-        // given
-        let theme: Theme = .dark
-        // when
-        sut.changeTheme(to: theme)
-        sut.applyTheme()
-        // then
-        let color = UILabel.appearance(whenContainedInInstancesOf: [UITableViewCell.self]).textColor
-        XCTAssertEqual(color, Theme.dark.style.titleTextColor)
-    }
-
     func testUILabelTextTextColorShouldChangeToTitleTextColorWhenContainedInUITableViewHeaderFooterViewAndNightModeWasSelected() {
         // given
         let theme: Theme = .dark


### PR DESCRIPTION
This PR adds the Observation mode (#41) and replaces the old GPS switch to disable posting updates to the backend. I also updated the UI for the No GPS overlay which no has a button that links directly to the system settings 

Light mode:

<img width="300" alt="Bildschirmfoto 2019-06-15 um 23 20 58" src="https://user-images.githubusercontent.com/7677738/59556533-52fa2d00-8fc4-11e9-92b4-d78a576c5bb6.png"><img width="300" alt="Bildschirmfoto 2019-06-15 um 23 21 00" src="https://user-images.githubusercontent.com/7677738/59556534-52fa2d00-8fc4-11e9-8409-f951faaac996.png">

Dark mode:


<img width="300" alt="Bildschirmfoto 2019-06-15 um 23 21 10" src="https://user-images.githubusercontent.com/7677738/59556537-5988a480-8fc4-11e9-9a85-bdd2c58cf227.png"><img width="300" alt="Bildschirmfoto 2019-06-15 um 23 21 06" src="https://user-images.githubusercontent.com/7677738/59556536-5988a480-8fc4-11e9-9882-a699d7828f2c.png">