### PR TITLE
iOS 13 improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog for Critical Maps iOS
 
 ## [UNRELEASED]
 
+### Added
+- iOS 13 support
+
 ### Fixed
 
 - A bug that made the app unusable with assistive technologies like Switch Control or VoiceOver

--- a/CriticalMass/AppDelegate.swift
+++ b/CriticalMass/AppDelegate.swift
@@ -21,7 +21,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #endif
 
         window = UIWindow(frame: UIScreen.main.bounds)
-        window?.backgroundColor = .white
         window?.rootViewController = appController.rootViewController
         window?.makeKeyAndVisible()
 

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -59,15 +59,16 @@ class MapViewController: UIViewController {
         guard themeController.currentTheme == .dark else {
             return
         }
-        if #available(iOS 13.0, *) {
-            // This is a workaround to make the compiler with Xcode 10 happy
-            #if canImport(SwiftUI)
+
+        // This is a workaround to make the compiler with Xcode 10 happy
+        #if canImport(SwiftUI)
+            if #available(iOS 13.0, *) {
                 mapView.overrideUserInterfaceStyle = .dark
-            #endif
-        } else {
-            tileRenderer = MKTileOverlayRenderer(tileOverlay: nightThemeOverlay)
-            mapView.addOverlay(nightThemeOverlay, level: .aboveRoads)
-        }
+            } else {
+                addTileRenderer()
+            }
+        #endif
+        addTileRenderer()
     }
 
     private func condfigureGPSDisabledOverlayView() {
@@ -147,18 +148,29 @@ class MapViewController: UIViewController {
     @objc private func themeDidChange() {
         let theme = themeController.currentTheme
         guard theme == .dark else {
-            if #available(iOS 13.0, *) {
-                // This is a workaround to make the compiler with Xcode 10 happy
-                #if canImport(SwiftUI)
+            // This is a workaround to make the compiler with Xcode 10 happy
+            #if canImport(SwiftUI)
+                if #available(iOS 13.0, *) {
                     mapView.overrideUserInterfaceStyle = .unspecified
-                #endif
-            } else {
-                tileRenderer = nil
-                mapView.removeOverlay(nightThemeOverlay)
-            }
+                } else {
+                    removeTileRenderer()
+                }
+            #else
+                removeTileRenderer()
+            #endif
             return
         }
         configureTileRenderer()
+    }
+
+    private func removeTileRenderer() {
+        tileRenderer = nil
+        mapView.removeOverlay(nightThemeOverlay)
+    }
+
+    private func addTileRenderer() {
+        tileRenderer = MKTileOverlayRenderer(tileOverlay: nightThemeOverlay)
+        mapView.addOverlay(nightThemeOverlay, level: .aboveRoads)
     }
 
     @objc private func positionsDidChange(notification: Notification) {

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -59,8 +59,15 @@ class MapViewController: UIViewController {
         guard themeController.currentTheme == .dark else {
             return
         }
-        tileRenderer = MKTileOverlayRenderer(tileOverlay: nightThemeOverlay)
-        mapView.addOverlay(nightThemeOverlay, level: .aboveRoads)
+        if #available(iOS 13.0, *) {
+            // This is a workaround to make the compiler with Xcode 10 happy
+            #if canImport(SwiftUI)
+                mapView.overrideUserInterfaceStyle = .dark
+            #endif
+        } else {
+            tileRenderer = MKTileOverlayRenderer(tileOverlay: nightThemeOverlay)
+            mapView.addOverlay(nightThemeOverlay, level: .aboveRoads)
+        }
     }
 
     private func condfigureGPSDisabledOverlayView() {
@@ -140,8 +147,15 @@ class MapViewController: UIViewController {
     @objc private func themeDidChange() {
         let theme = themeController.currentTheme
         guard theme == .dark else {
-            tileRenderer = nil
-            mapView.removeOverlay(nightThemeOverlay)
+            if #available(iOS 13.0, *) {
+                // This is a workaround to make the compiler with Xcode 10 happy
+                #if canImport(SwiftUI)
+                    mapView.overrideUserInterfaceStyle = .unspecified
+                #endif
+            } else {
+                tileRenderer = nil
+                mapView.removeOverlay(nightThemeOverlay)
+            }
             return
         }
         configureTileRenderer()

--- a/CriticalMass/ThemeDefining.swift
+++ b/CriticalMass/ThemeDefining.swift
@@ -150,7 +150,12 @@ struct DarkTheme: ThemeDefining {
     }
 
     var navigationBarIsTranslucent: Bool {
-        return false
+        if #available(iOS 13.0, *) {
+            // FIXME: Returning false would make the navigationbar transparent on iOS 13
+            return true
+        } else {
+            return false
+        }
     }
 
     var placeholderTextColor: UIColor {


### PR DESCRIPTION
Some small improvements for iOS 13 #113 

## Navigationbar background in Night mode 

<details><summary>before</summary>
<p>

<img width="456" alt="Bildschirmfoto 2019-06-28 um 14 33 25" src="https://user-images.githubusercontent.com/7677738/62819443-b7b1ae00-bb55-11e9-8e09-0dd17049d9fc.png">
</p>

after:
</details>
<img width="386" alt="Bildschirmfoto 2019-08-10 um 10 02 37" src="https://user-images.githubusercontent.com/7677738/62819462-03fcee00-bb56-11e9-9467-4c968be5b0a2.png">

It's still not perfect as the Navigationbar textColor only updates on reopening settings. We should try to adapt the new apis for iOS 13.

## System map for night mode on iOS 13 devices (only works if the version is compiled with Xcode 11)

<img width="386" alt="Bildschirmfoto 2019-08-10 um 09 36 11" src="https://user-images.githubusercontent.com/7677738/62819436-a072c080-bb55-11e9-8f2a-cbe517765393.png">

## Background for modal presentations

<details><summary>before</summary>
<p>

<img width="386" alt="Bildschirmfoto 2019-08-10 um 09 24 27" src="https://user-images.githubusercontent.com/7677738/62819452-d87a0380-bb55-11e9-8b86-aad02fdd1bad.png">
</p>

after:
</details>

<img width="386" alt="Bildschirmfoto 2019-08-10 um 09 24 42" src="https://user-images.githubusercontent.com/7677738/62819453-da43c700-bb55-11e9-84fa-e07c7716c8e4.png">
