### PR TITLE
Improve network error

### DIFF
--- a/CriticalMass/ChatManager.swift
+++ b/CriticalMass/ChatManager.swift
@@ -46,7 +46,7 @@ class ChatManager {
                 completion(.success(messages))
             case let .failure(error):
                 ErrorHandler.default.handleError(error)
-                completion(.failure(NetworkError.fetchFailed(error)))
+                completion(.failure(error))
             }
         }
     }

--- a/CriticalMass/MessagesTableViewController.swift
+++ b/CriticalMass/MessagesTableViewController.swift
@@ -16,7 +16,7 @@ typealias IBConstructableMessageTableViewCell = UITableViewCell & IBConstructabl
 
 class MessagesTableViewController<T: IBConstructableMessageTableViewCell>: UITableViewController {
     var noContentMessage: String?
-    var pullToRefreshTrigger: (((() -> Void)?) -> Void)? {
+    var pullToRefreshTrigger: ((ResultCallback<[Tweet]>?) -> Void)? {
         didSet {
             let control = UIRefreshControl()
             refreshControl = control
@@ -58,7 +58,7 @@ class MessagesTableViewController<T: IBConstructableMessageTableViewCell>: UITab
 
     @objc private func didTriggerRefresh() {
         refreshControl?.beginRefreshing()
-        pullToRefreshTrigger? { [weak self] in
+        pullToRefreshTrigger? { [weak self] _ in
             self?.refreshControl?.endRefreshing()
         }
     }

--- a/CriticalMass/NetworkLayer.swift
+++ b/CriticalMass/NetworkLayer.swift
@@ -16,6 +16,25 @@ enum NetworkError: Error {
     case invalidResponse
 }
 
+extension NetworkError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case let .noData(error):
+            return "Data is nil: Error:\(error)"
+        case let .decodingError(error):
+            return "Failed to decode data. Error: \(error)"
+        case let .encodingError(error):
+            return "Failed to encode body. Error: \(error)"
+        case let .fetchFailed(error):
+            return "Fetch Failed with error: \(error)"
+        case .invalidResponse:
+            return "Response is not vaild."
+        case let .unknownError(message):
+            return "UnknownError: \(message)"
+        }
+    }
+}
+
 enum HTTPMethod: String {
     case get = "GET"
     case post = "POST"

--- a/CriticalMass/NetworkLayer.swift
+++ b/CriticalMass/NetworkLayer.swift
@@ -9,8 +9,11 @@ import Foundation
 
 enum NetworkError: Error {
     case fetchFailed(Error?)
-    case unknownError
-    case parseError
+    case unknownError(message: String)
+    case decodingError(Error)
+    case encodingError(Encodable)
+    case noData(Error?)
+    case invalidResponse
 }
 
 enum HTTPMethod: String {

--- a/CriticalMass/NetworkOperator.swift
+++ b/CriticalMass/NetworkOperator.swift
@@ -29,8 +29,8 @@ struct NetworkOperator: NetworkLayer {
                 do {
                     let responseData = try request.parseResponse(data: data)
                     completion(.success(responseData))
-                } catch {
-                    completion(.failure(NetworkError.parseError))
+                } catch let decodingError {
+                    completion(.failure(NetworkError.decodingError(decodingError)))
                 }
             }
         }
@@ -47,8 +47,8 @@ struct NetworkOperator: NetworkLayer {
                 do {
                     let responseData = try request.parseResponse(data: data)
                     completion(.success(responseData))
-                } catch {
-                    completion(.failure(NetworkError.parseError))
+                } catch let decodingError {
+                    completion(.failure(NetworkError.decodingError(decodingError)))
                 }
             }
         }

--- a/CriticalMass/NetworkOperator.swift
+++ b/CriticalMass/NetworkOperator.swift
@@ -10,7 +10,7 @@ import Foundation
 struct NetworkOperator: NetworkLayer {
     private let session: URLSession
     private var networkIndicatorHelper: NetworkActivityIndicatorHelper
-    private static let validHttpResponseCodes = 200 ..< 300
+    private static let validHttpResponseCodes = 200 ..< 299
 
     init(networkIndicatorHelper: NetworkActivityIndicatorHelper) {
         let configuration = URLSessionConfiguration.default

--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -96,12 +96,12 @@ public class RequestManager {
 
     func send(messages: [SendChatMessage], completion: @escaping ResultCallback<[String: ChatMessage]>) {
         let backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask {
-            completion(.failure(NetworkError.unknownError))
+            completion(.failure(NetworkError.unknownError(message: "Send message: backgroundTask failed")))
             self.networkLayer.cancelActiveRequestsIfNeeded()
         }
         let body = SendMessagePostBody(device: idProvider.id, messages: messages)
         guard let bodyData = try? body.encoded() else {
-            completion(.failure(NetworkError.parseError))
+            completion(.failure(NetworkError.encodingError(body)))
             return
         }
         let request = PostChatMessagesRequest()

--- a/CriticalMass/TwitterManager.swift
+++ b/CriticalMass/TwitterManager.swift
@@ -24,19 +24,20 @@ class TwitterManager {
         self.url = url
     }
 
-    public func loadTweets(_ completion: (() -> Void)? = nil) {
+    public func loadTweets(_ completion: ResultCallback<[Tweet]>? = nil) {
         let getTweetsRequest = TwitterRequest()
         networkLayer.get(request: getTweetsRequest) { [weak self] result in
             guard let self = self else { return }
             onMain {
                 switch result {
                 case let .failure(error):
+                    completion?(.failure(error))
                     ErrorHandler.default.handleError(error)
                 case let .success(response):
                     self.cachedTweets = response.statuses
+                    completion?(.success(response.statuses))
                 }
             }
-            completion?()
         }
     }
 

--- a/CriticalMassTests/TestHelper.swift
+++ b/CriticalMassTests/TestHelper.swift
@@ -34,7 +34,7 @@ class MockNetworkLayer: NetworkLayer {
         numberOfGetCalled += 1
         if shouldReturnResponse {
             guard let response = mockResponse as? T.ResponseDataType else {
-                completion(.failure(NetworkError.unknownError))
+                completion(.failure(NetworkError.unknownError(message: "Should be ResponseDataType")))
                 return
             }
             completion(.success(response))

--- a/CriticalMassTests/TestHelper.swift
+++ b/CriticalMassTests/TestHelper.swift
@@ -46,7 +46,7 @@ class MockNetworkLayer: NetworkLayer {
         lastUsedPostBody = try! JSONSerialization.jsonObject(with: bodyData, options: []) as! [String: Any]
         if shouldReturnResponse {
             guard let response = mockResponse as? T.ResponseDataType else {
-                completion(.failure(NetworkError.unknownError))
+                completion(.failure(NetworkError.unknownError(message: "Should be ResponseDataType")))
                 return
             }
             completion(.success(response))

--- a/CriticalMassTests/TwitterManagerTests.swift
+++ b/CriticalMassTests/TwitterManagerTests.swift
@@ -48,7 +48,7 @@ class TwitterManagerTests: XCTestCase {
         let fakeResponse = TwitterApiResponse(statuses: [Tweet(text: "Hello World", created_at: Date(), user: TwitterUser(name: "Test", screen_name: "Foo", profile_image_url_https: "haa")), Tweet(text: "Test Test", created_at: Date(), user: TwitterUser(name: "Hello World", screen_name: "Bar", profile_image_url_https: "differentURL"))])
 
         setup.networkLayer.mockResponse = fakeResponse
-        setup.twitterManager.loadTweets {
+        setup.twitterManager.loadTweets { _ in
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1)
@@ -60,7 +60,7 @@ class TwitterManagerTests: XCTestCase {
         let exp = expectation(description: "Update Tweets callback called")
 
         setup.networkLayer.mockResponse = nil
-        setup.twitterManager.loadTweets {
+        setup.twitterManager.loadTweets { _ in
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1)


### PR DESCRIPTION
This PR will make error creation a little bit more verbose to make finding errors easier.

```swift
enum NetworkError: Error {
    case fetchFailed(Error?)
    case unknownError(message: String)
    case decodingError(Error)
    case encodingError(Encodable)
    case noData(Error?)
    case invalidResponse
}
```