### PR TITLE
Fix NavigationBar colors under iOS 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-language: objective-c 
-osx_image: xcode10.3
+language: objective-c
+osx_image: xcode11
 
 before_install:
   - bundle update
 
 script:
-    - bundle exec fastlane test
+  - bundle exec fastlane test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changelog for Critical Maps iOS
 
+## [Unreleased]
+
+Fix: NavigationBar Colors under iOS 13 
+
 ## [3.3.0] - 2019-09-01
 
 ### Added

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -53,6 +53,7 @@ class ThemeController {
             appearance.configureWithOpaqueBackground()
             appearance.backgroundColor = theme.backgroundColor
             appearance.largeTitleTextAttributes = [.foregroundColor: theme.titleTextColor]
+            appearance.titleTextAttributes = [.foregroundColor: theme.titleTextColor]
             UINavigationBar.appearance().scrollEdgeAppearance = appearance
             UINavigationBar.appearance().standardAppearance = appearance
         }

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -47,6 +47,15 @@ class ThemeController {
     private func styleRulesComponents(with theme: ThemeDefining) {
         RuleTableViewCell.appearance().ruleTextColor = theme.titleTextColor
         RuleDetailTextView.appearance().ruleDetailTextColor = theme.titleTextColor
+
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = theme.backgroundColor
+            appearance.largeTitleTextAttributes = [.foregroundColor: theme.titleTextColor]
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+            UINavigationBar.appearance().standardAppearance = appearance
+        }
     }
 
     private func styleSettingsComponents(with theme: ThemeDefining) {
@@ -71,8 +80,14 @@ class ThemeController {
 
     private func styleSocialComponets(with theme: ThemeDefining) {
         // UISegmentedControl
-        UISegmentedControl.appearance().backgroundColor = theme.backgroundColor
-        UISegmentedControl.appearance(whenContainedInInstancesOf: [UIToolbar.self]).tintColor = theme.titleTextColor
+        if #available(iOS 13.0, *) {
+            UISegmentedControl.appearance().selectedSegmentTintColor = theme.titleTextColor
+            UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: theme.backgroundColor], for: .selected)
+            UISegmentedControl.appearance().setTitleTextAttributes([.foregroundColor: theme.titleTextColor], for: .normal)
+        } else {
+            UISegmentedControl.appearance().backgroundColor = theme.backgroundColor
+            UISegmentedControl.appearance().tintColor = theme.titleTextColor
+        }
         TweetTableViewCell.appearance().dateLabelTextColor = theme.secondaryTitleTextColor
         TweetTableViewCell.appearance().handleLabelTextColor = theme.thirdTitleTextColor
         TweetTableViewCell.appearance().userameTextColor = theme.titleTextColor

--- a/CriticalMass/ThemeDefining.swift
+++ b/CriticalMass/ThemeDefining.swift
@@ -76,7 +76,7 @@ struct LightTheme: ThemeDefining {
     }
 
     var navigationBarIsTranslucent: Bool {
-        return true
+        return false
     }
 
     var placeholderTextColor: UIColor {
@@ -150,12 +150,7 @@ struct DarkTheme: ThemeDefining {
     }
 
     var navigationBarIsTranslucent: Bool {
-        if #available(iOS 13.0, *) {
-            // FIXME: Returning false would make the navigationbar transparent on iOS 13
-            return true
-        } else {
-            return false
-        }
+        return false
     }
 
     var placeholderTextColor: UIColor {


### PR DESCRIPTION
This should fix navigationbar colors under iOS 13 which currently don't look right in XCode Sims.
Let's hope 13.1 does not change that :D

**Screenshots**
<img width="487" alt="Screenshot 2019-09-21 at 15 43 50" src="https://user-images.githubusercontent.com/14075359/65374349-59fe9e80-dc89-11e9-9691-9ba33ee1d756.png"><img width="487" alt="Screenshot 2019-09-21 at 16 06 41" src="https://user-images.githubusercontent.com/14075359/65374411-da250400-dc89-11e9-934d-10cf2db9bad7.png">

<img width="487" alt="Screenshot 2019-09-21 at 15 44 03" src="https://user-images.githubusercontent.com/14075359/65374466-78b16500-dc8a-11e9-804a-d3cbebf9eff1.png"><img width="487" alt="Screenshot 2019-09-21 at 15 31 51" src="https://user-images.githubusercontent.com/14075359/65374467-7cdd8280-dc8a-11e9-943f-d62b2de07fbf.png">


## Checklist

### Before merging the PR

- [x] If applicable, did you add a before / after screenshot of the feature?
- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?
