### PR TITLE
Adopt dark mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-language: objective-c 
-osx_image: xcode10.3
+language: objective-c
+osx_image: xcode11
 
 before_install:
   - bundle update
 
 script:
-    - bundle exec fastlane test
+  - bundle exec fastlane test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changelog for Critical Maps iOS
 
+## [Unreleased]
+
+- Set userStyle as Theme under iOS 13
+
 ## [3.3.0] - 2019-09-01
 
 ### Added

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -147,16 +147,11 @@ class MapViewController: UIViewController {
     @objc private func themeDidChange() {
         let theme = themeController.currentTheme
         guard theme == .dark else {
-            // This is a workaround to make the compiler with Xcode 10 happy
-            #if canImport(SwiftUI)
                 if #available(iOS 13.0, *) {
-                    mapView.overrideUserInterfaceStyle = .unspecified
+                overrideUserInterfaceStyle = .light
                 } else {
                     removeTileRenderer()
                 }
-            #else
-                removeTileRenderer()
-            #endif
             return
         }
         configureTileRenderer()

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -57,18 +57,17 @@ class MapViewController: UIViewController {
 
     private func configureTileRenderer() {
         guard themeController.currentTheme == .dark else {
+            if #available(iOS 13.0, *) {
+                overrideUserInterfaceStyle = .light
+            }
             return
         }
 
-        // This is a workaround to make the compiler with Xcode 10 happy
-        #if canImport(SwiftUI)
-            if #available(iOS 13.0, *) {
-                mapView.overrideUserInterfaceStyle = .dark
-            } else {
-                addTileRenderer()
-            }
-        #endif
-        addTileRenderer()
+        if #available(iOS 13.0, *) {
+            overrideUserInterfaceStyle = .dark
+        } else {
+            addTileRenderer()
+        }
     }
 
     private func condfigureGPSDisabledOverlayView() {

--- a/CriticalMass/Theme.swift
+++ b/CriticalMass/Theme.swift
@@ -12,6 +12,18 @@ enum Theme: Int {
     case light
     case dark
 
+    @available(iOS 12.0, *)
+    init(userInterfaceStyle: UIUserInterfaceStyle) {
+        switch userInterfaceStyle {
+        case .dark:
+            self = .dark
+        case .light, .unspecified:
+            self = .light
+        @unknown default:
+            self = .light
+        }
+    }
+
     var style: ThemeDefining {
         switch self {
         case .light:

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -10,11 +10,12 @@ import Foundation
 import UIKit
 
 class ThemeController {
-    private(set) lazy var currentTheme = loadTheme()
+    private(set) var currentTheme: Theme!
     private let store: ThemeStorable
 
     init(store: ThemeStorable = ThemeSelectionStore()) {
         self.store = store
+        currentTheme = loadTheme()
     }
 
     func changeTheme(to theme: Theme) {

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -25,7 +25,12 @@ class ThemeController {
 
     private func loadTheme() -> Theme {
         guard let theme = store.load() else {
-            return .light
+            if #available(iOS 13.0, *) {
+                let theme = Theme(userInterfaceStyle: UITraitCollection.current.userInterfaceStyle)
+                return theme
+            } else {
+                return .light
+            }
         }
         return theme
     }

--- a/CriticalMass/ThemeStore.swift
+++ b/CriticalMass/ThemeStore.swift
@@ -32,7 +32,9 @@ class ThemeSelectionStore: ThemeStorable {
     ///
     /// - Returns: Saved Theme from a previous session.
     func load() -> Theme? {
-        let storedTheme = defaults.integer(forKey: defaultsKey)
+        guard let storedTheme = defaults.object(forKey: defaultsKey) as? Int else {
+            return nil
+        }
         return Theme(rawValue: storedTheme)
     }
 }

--- a/CriticalMassTests/ThemeStoreTests.swift
+++ b/CriticalMassTests/ThemeStoreTests.swift
@@ -13,45 +13,11 @@ class MockThemeStore: ThemeStorable {
     private var currentTheme: Theme?
 
     func load() -> Theme? {
-        guard let theme = currentTheme else {
-            return .light
-        }
-        return theme
+        return currentTheme
     }
 
     func save(_ themeSelection: Theme) {
         currentTheme = themeSelection
-    }
-}
-
-class MockThemeStoreTests: XCTestCase {
-    var sut: ThemeStorable?
-
-    override func setUp() {
-        super.setUp()
-        sut = MockThemeStore()
-    }
-
-    override func tearDown() {
-        sut = nil
-        super.tearDown()
-    }
-
-    func testStoreShouldReturnLightThemeWhenNothingIsSavedBefore() {
-        // given
-        let theme = sut!.load()
-        // then
-        XCTAssertEqual(theme, .light)
-    }
-
-    func testStoreShouldReturnDarkThemeWhenDarkIsSavedBefore() {
-        // given
-        let theme = Theme.dark
-        // when
-        sut?.save(theme)
-        let loadedTheme = sut!.load()
-        // then
-        XCTAssertEqual(loadedTheme, .dark)
     }
 }
 

--- a/CriticalMassTests/ThemeStoreTests.swift
+++ b/CriticalMassTests/ThemeStoreTests.swift
@@ -70,11 +70,11 @@ class ThemeSelectionStoreTests: XCTestCase {
         super.tearDown()
     }
 
-    func testStoreShouldReturnLightThemeWhenNothingIsSavedBefore() {
+    func testStoreShouldReturnNilThemeWhenNothingIsSavedBefore() {
         // given
         let theme = sut!.load()
         // then
-        XCTAssertEqual(theme, .light)
+        XCTAssertNil(theme)
     }
 
     func testStoreShouldReturnDarkThemeWhenDarkIsSavedBefore() {


### PR DESCRIPTION
This PR will set the Apps Theme to the system Theme under iOS13, when the user did not set a theme before. Until the user sets a theme in the app, the systemwide userStyle will be used.

<img width="479" alt="Screenshot 2019-09-21 at 18 47 24" src="https://user-images.githubusercontent.com/14075359/65376516-e799b880-dca0-11e9-960e-0e53e5aedd3d.png">
<img width="487" alt="Screenshot 2019-09-21 at 18 45 47" src="https://user-images.githubusercontent.com/14075359/65376517-e8324f00-dca0-11e9-863e-1a052dfa1376.png">
<img width="487" alt="Screenshot 2019-09-21 at 18 45 54" src="https://user-images.githubusercontent.com/14075359/65376518-e8324f00-dca0-11e9-93bd-0c5926e0efcc.png">

## Checklist

### Before merging the PR

- [x] If applicable, did you add a before / after screenshot of the feature?
- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?
