### PR TITLE
Move Chat Presentation to viewDidLoad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Changelog for Critical Maps iOS
 
+## [Unreleased]
+
+### Fixed
+
+- Fix: Don't update content when slightly swipe down in Social Modal
+
 ## [3.4.0] - 2019-10-08
 
 ### Added
@@ -16,7 +22,6 @@ Changelog for Critical Maps iOS
 - Fix: NavigationBar Colors under iOS 13 
 - Fix: UITableViewHeaderFooterView backgroundColor deprecation warning
 - Fix: Ambiguous auto layout constraints for Settings screen
-- Fix: Don't update content when slightly swipe down in Social Modal
 
 ## [3.3.0] - 2019-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog for Critical Maps iOS
 - Fix: NavigationBar Colors under iOS 13 
 - Fix: UITableViewHeaderFooterView backgroundColor deprecation warning
 - Fix: Ambiguous auto layout constraints for Settings screen
+- Fix: Don't update content when slightly swipe down in Social Modal
 
 ## [3.3.0] - 2019-09-01
 

--- a/CriticalMass/SocialViewController.swift
+++ b/CriticalMass/SocialViewController.swift
@@ -44,10 +44,6 @@ class SocialViewController: UIViewController, UIToolbarDelegate {
         super.viewDidLoad()
         configureSegmentedControl()
         configureNavigationBar()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         present(segment: .chat)
     }
 


### PR DESCRIPTION
Fixes #171 

This moves the call from `viewWillAppear` to `viewDidLoad`, because when you slightly pull down the modal with the swipe gesture `viewWillAppear` gets called and changes the content. Everytime the modal is presented `viewDidLoad` is called, so I think this is the better place to setup the content. 

![dismiss-correct](https://user-images.githubusercontent.com/26111180/67307674-249fd780-f4f9-11e9-84d9-afc59e9eaed0.gif)

## Checklist

### Before merging the PR

- [ ] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

