### PR TITLE
Fixed UITests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ jobs:
   include:
     - script: bundle exec fastlane test
       name: UnitTests
-    - script: bundle exec fastlane screenshots_limited
+    - script: bundle exec fastlane ui_test
       name: UITests

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,6 +41,18 @@ platform :ios do
       scheme: Scheme_UnitTests
     )
   end
+
+
+  desc 'Run UITests'
+  lane :ui_test do
+    sh "cd .. && xcodebuild -resolvePackageDependencies"
+
+    run_tests(
+      build_for_testing: true,
+      device: 'iPhone 8',
+      scheme: Scheme_UITests
+    )
+  end
   
   desc 'Make screenshots with all languages and different devices'
   lane :screenshots_complete do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,7 +48,6 @@ platform :ios do
     sh "cd .. && xcodebuild -resolvePackageDependencies"
 
     run_tests(
-      build_for_testing: true,
       device: 'iPhone 8',
       scheme: Scheme_UITests
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,7 +36,6 @@ platform :ios do
     sh "cd .. && xcodebuild -resolvePackageDependencies"
 
     run_tests(
-      build_for_testing: true,
       device: 'iPhone 8',
       scheme: Scheme_UnitTests
     )

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -3,7 +3,7 @@
 # A list of devices you want to take the screenshots from
 
 # We need to check if the iPhone SE is installed which is not the case on current Travis environments, but we still wanna keep it if possible
-if `xcrun simctl list | grep "SE"`.length > 0
+if `xcrun simctl list | grep "iPhone SE"`.length > 0
   devices([
     "iPhone 8",
     "iPhone 8 Plus",

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -2,6 +2,7 @@
 
 # A list of devices you want to take the screenshots from
 
+# We need to check if the iPhone SE is installed which is not the case on current Travis environments, but we still wanna keep it if possible
 if `xcrun simctl list | grep "SE"`.length > 0
   devices([
     "iPhone 8",

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -2,23 +2,13 @@
 
 # A list of devices you want to take the screenshots from
 
-# We need to check if the iPhone SE is installed which is not the case on current Travis environments, but we still wanna keep it if possible
-if `xcrun simctl list | grep "iPhone SE"`.length > 0
-  devices([
-    "iPhone 8",
-    "iPhone 8 Plus",
-    "iPhone SE",
-    "iPhone X",
-    "iPhone 11 Pro Max"
-  ])
-else
-  devices([
-    "iPhone 8",
-    "iPhone 8 Plus",
-    "iPhone X",
-    "iPhone 11 Pro Max"
-  ])
-end 
+devices([
+  "iPhone 8",
+  "iPhone 8 Plus",
+  "iPhone SE",
+  "iPhone X",
+  "iPhone 11 Pro Max"
+])
 
 languages([
   "en-US",

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,7 +1,6 @@
 # Uncomment the lines below you want to change by removing the # in the beginning
 
 # A list of devices you want to take the screenshots from
-
 devices([
   "iPhone 8",
   "iPhone 8 Plus",

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,13 +1,23 @@
 # Uncomment the lines below you want to change by removing the # in the beginning
 
 # A list of devices you want to take the screenshots from
-devices([
-  "iPhone 8",
-  "iPhone 8 Plus",
-  "iPhone SE",
-  "iPhone X",
-  "iPhone 11 Pro Max"
-])
+
+if `xcrun simctl list | grep "SE"`.length > 0
+  devices([
+    "iPhone 8",
+    "iPhone 8 Plus",
+    "iPhone SE",
+    "iPhone X",
+    "iPhone 11 Pro Max"
+  ])
+else
+  devices([
+    "iPhone 8",
+    "iPhone 8 Plus",
+    "iPhone X",
+    "iPhone 11 Pro Max"
+  ])
+end 
 
 languages([
   "en-US",


### PR DESCRIPTION
Travis Xcode version doesn't has the iPhone SE installed, which breaks our UITests. Removing SE from the snap file in case it's not installed fixes the issue