### PR TITLE
Fix action indicator visibility in Dark Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for Critical Maps iOS
 
 - Fix: Don't update content when slightly swipe down in Social Modal
 - Fix whitespace only chat message can not be send anymore.
+- Fix: Action indicator visibility in Dark Mode
 
 ## [3.4.0] - 2019-10-08
 

--- a/CriticalMass/RuleTableViewCell.xib
+++ b/CriticalMass/RuleTableViewCell.xib
@@ -1,40 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="60" id="KGk-i7-Jjw" customClass="RuleTableViewCell" customModule="CriticalMaps" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="60" id="KGk-i7-Jjw" customClass="RuleTableViewCell" customModule="CriticalMaps" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MPX-Kp-ebL">
-                        <rect key="frame" x="16" y="16" width="254" height="11.5"/>
+                        <rect key="frame" x="16" y="16" width="288" height="12"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qPK-8w-i6s">
+                        <rect key="frame" x="284" y="4" width="30" height="36"/>
+                        <accessibility key="accessibilityConfiguration">
+                            <accessibilityTraits key="traits" staticText="YES"/>
+                        </accessibility>
+                        <fontDescription key="fontDescription" name="EuphemiaUCAS" family="Euphemia UCAS" pointSize="18"/>
+                        <state key="normal" title="&gt;">
+                            <color key="titleColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </state>
+                    </button>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="MPX-Kp-ebL" secondAttribute="trailing" constant="16" id="13U-Gu-HmJ"/>
+                    <constraint firstItem="qPK-8w-i6s" firstAttribute="centerY" secondItem="MPX-Kp-ebL" secondAttribute="centerY" id="Sw0-KP-dCB"/>
                     <constraint firstItem="MPX-Kp-ebL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="V3D-Ko-LqU"/>
                     <constraint firstAttribute="bottom" secondItem="MPX-Kp-ebL" secondAttribute="bottom" constant="16" id="aJx-ao-gbX"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="qPK-8w-i6s" secondAttribute="trailing" constant="-9" id="fSv-RN-xL7"/>
                     <constraint firstItem="MPX-Kp-ebL" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="pcC-lF-Btl"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="label" destination="MPX-Kp-ebL" id="g1s-GT-cXe"/>
             </connections>
+            <point key="canvasLocation" x="133" y="155"/>
         </tableViewCell>
     </objects>
 </document>

--- a/CriticalMass/SettingsGithubTableViewCellTableViewCell.xib
+++ b/CriticalMass/SettingsGithubTableViewCellTableViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,14 +13,14 @@
             <rect key="frame" x="0.0" y="0.0" width="400" height="234"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="400" height="233.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="400" height="234"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="GithubBanner" translatesAutoresizingMaskIntoConstraints="NO" id="VXc-gu-JtL">
-                        <rect key="frame" x="16" y="16" width="368" height="193.5"/>
+                        <rect key="frame" x="16" y="16" width="368" height="194"/>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="b5G-Gd-zcX">
-                        <rect key="frame" x="36" y="36" width="328" height="153.5"/>
+                        <rect key="frame" x="36" y="36" width="328" height="154"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Vermisst du Funktionen oder willst einen Bug fixen?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fii-3b-jwj">
                                 <rect key="frame" x="0.0" y="0.0" width="327" height="42.5"/>
@@ -31,29 +29,29 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Critical Maps ist ein Open Source Projekt und wir feuen uns über Entwickler*innen die an Critical Maps mitarbeiten wollen." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q47-2o-kHV">
-                                <rect key="frame" x="0.0" y="54.5" width="313.5" height="69"/>
+                                <rect key="frame" x="0.0" y="54.5" width="313.5" height="59.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="yjg-8l-o9D">
-                                <rect key="frame" x="0.0" y="135.5" width="165" height="18"/>
+                                <rect key="frame" x="0.0" y="126" width="185" height="28"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="PROJEKT ANSEHEN" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2xr-Tp-a5U">
-                                        <rect key="frame" x="0.0" y="0.0" width="139" height="18"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="139" height="28"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ArrowButton" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MCh-Zj-FA7">
-                                        <rect key="frame" x="149" y="0.0" width="16" height="18"/>
+                                        <rect key="frame" x="149" y="0.0" width="36" height="28"/>
                                     </imageView>
                                 </subviews>
                             </stackView>
                         </subviews>
                     </stackView>
                     <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dIQ-Qg-C4y">
-                        <rect key="frame" x="16" y="16" width="368" height="193.5"/>
+                        <rect key="frame" x="16" y="16" width="368" height="194"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                 </subviews>

--- a/CriticalMass/SettingsInfoTableViewCell.xib
+++ b/CriticalMass/SettingsInfoTableViewCell.xib
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="56" id="KGk-i7-Jjw" customClass="SettingsInfoTableViewCell" customModule="CriticalMaps" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="56" id="KGk-i7-Jjw" customClass="SettingsInfoTableViewCell" customModule="CriticalMaps" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="286" height="55.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2OT-T5-zK2">
-                        <rect key="frame" x="16" y="0.0" width="262" height="56.5"/>
+                        <rect key="frame" x="15" y="0.0" width="290" height="56"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="56" id="05X-sx-N3A"/>
                         </constraints>
@@ -27,6 +25,16 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yPO-6i-1Ka">
+                        <rect key="frame" x="284" y="10" width="30" height="36"/>
+                        <accessibility key="accessibilityConfiguration">
+                            <accessibilityTraits key="traits" staticText="YES"/>
+                        </accessibility>
+                        <fontDescription key="fontDescription" name="EuphemiaUCAS" family="Euphemia UCAS" pointSize="18"/>
+                        <state key="normal" title="&gt;">
+                            <color key="titleColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </state>
+                    </button>
                 </subviews>
                 <constraints>
                     <constraint firstItem="2OT-T5-zK2" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="6Es-fJ-u4j"/>
@@ -34,6 +42,8 @@
                     <constraint firstAttribute="trailingMargin" secondItem="2OT-T5-zK2" secondAttribute="trailing" id="MxR-yx-5yL"/>
                     <constraint firstItem="2OT-T5-zK2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Yz5-8U-eks"/>
                     <constraint firstItem="2OT-T5-zK2" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="tLu-PD-THV"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="yPO-6i-1Ka" secondAttribute="trailing" constant="-9" id="vmU-1l-4Sg"/>
+                    <constraint firstItem="yPO-6i-1Ka" firstAttribute="centerY" secondItem="2OT-T5-zK2" secondAttribute="centerY" id="y0P-TA-RKb"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>

--- a/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -1,24 +1,4 @@
-name: NSString-Hashes, nameSpecified: 
-body: Public Domain
-…
-version: 1.2.2
-
-name: NSString-Hashes, nameSpecified: 
-body: Public Domain
-…
-version: 1.2.2
-
-name: SDWebImage, nameSpecified: 
-body: Copyright (c) 2009-2…
-version: 5.0.1
-
-name: SwiftFormat, nameSpecified: 
-body: MIT License
-
-Copyrig…
-version: 0.40.8
-
-name: SDWebImage, nameSpecified: , owner: SDWebImage, version: 5.2.2
+name: SDWebImage, nameSpecified: , owner: SDWebImage, version: 5.2.5
 
 name: SwiftHash, nameSpecified: , owner: onmyway133, version: 2.0.2
 

--- a/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -12,25 +12,9 @@
 		</dict>
 		<dict>
 			<key>File</key>
-			<string>com.mono0926.LicensePlist/NSString-Hashes</string>
-			<key>Title</key>
-			<string>NSString-Hashes</string>
-			<key>Type</key>
-			<string>PSChildPaneSpecifier</string>
-		</dict>
-		<dict>
-			<key>File</key>
 			<string>com.mono0926.LicensePlist/SDWebImage</string>
 			<key>Title</key>
 			<string>SDWebImage</string>
-			<key>Type</key>
-			<string>PSChildPaneSpecifier</string>
-		</dict>
-		<dict>
-			<key>File</key>
-			<string>com.mono0926.LicensePlist/SwiftFormat</string>
-			<key>Title</key>
-			<string>SwiftFormat</string>
 			<key>Type</key>
 			<string>PSChildPaneSpecifier</string>
 		</dict>


### PR DESCRIPTION
## Thank you for your contribution! 

Fixes #175 
Added a small workaround for activity indicator visibility in Dark Mode. Fixed by adding a button and setting the color, instead of system Disclosure Indicator.

## Checklist

### Before merging the PR

- [ ] If applicable, does the PR contain enough unit / UI tests?
- [ ] If applicable, did you add a before / after screenshot of the feature?
- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

![Activity-indicator-in-dark-mode-screenshot](https://user-images.githubusercontent.com/42268759/67804443-5b2fa200-fa65-11e9-92b4-4e22105b1734.png)
