### PR TITLE
MapViewController Refactoring

### DIFF
--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		9843FAA3236CDC0D00457930 /* NetworkOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9843FAA2236CDC0D00457930 /* NetworkOperatorTests.swift */; };
 		9843FAA5236CDC6E00457930 /* MockNetworkDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9843FAA4236CDC6E00457930 /* MockNetworkDataProvider.swift */; };
 		9844438123429354005468B2 /* UIView+Autolayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9844438023429354005468B2 /* UIView+Autolayout.swift */; };
+		9853B50F237E0E8D00F46AB6 /* MKMapView+Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9853B50E237E0E8D00F46AB6 /* MKMapView+Register.swift */; };
 		985E94B9220796CB00AA991B /* NavigationOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985E94B8220796CB00AA991B /* NavigationOverlayViewController.swift */; };
 		986749F8235230CB00BF5D6E /* Crypto in Frameworks */ = {isa = PBXBuildFile; productRef = 986749F7235230CB00BF5D6E /* Crypto */; };
 		98790021222DA7E600880334 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98790020222DA7E600880334 /* AppDelegate.swift */; };
@@ -314,6 +315,7 @@
 		9843FAA2236CDC0D00457930 /* NetworkOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkOperatorTests.swift; sourceTree = "<group>"; };
 		9843FAA4236CDC6E00457930 /* MockNetworkDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkDataProvider.swift; sourceTree = "<group>"; };
 		9844438023429354005468B2 /* UIView+Autolayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Autolayout.swift"; sourceTree = "<group>"; };
+		9853B50E237E0E8D00F46AB6 /* MKMapView+Register.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MKMapView+Register.swift"; sourceTree = "<group>"; };
 		985E94B8220796CB00AA991B /* NavigationOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationOverlayViewController.swift; sourceTree = "<group>"; };
 		98790020222DA7E600880334 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		987E3BD72368C6E100BAEFE7 /* MemoryDataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemoryDataStore.swift; sourceTree = "<group>"; };
@@ -463,6 +465,7 @@
 				948509A222C09F9A0034FAF1 /* UIViewController+Management.swift */,
 				940643D72307270B00AB1BCB /* GCD+Util.swift */,
 				9844438023429354005468B2 /* UIView+Autolayout.swift */,
+				9853B50E237E0E8D00F46AB6 /* MKMapView+Register.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -1138,6 +1141,7 @@
 				94FCBD3D226C583F00F93F94 /* SettingsTableSectionHeader.swift in Sources */,
 				98329A1F22D3BEA000A157EE /* KeychainHelper.swift in Sources */,
 				989F9FF421C7E64900E71085 /* RulesDetailViewController.swift in Sources */,
+				9853B50F237E0E8D00F46AB6 /* MKMapView+Register.swift in Sources */,
 				9460B76B225A6EB200786E27 /* FormatDisplay.swift in Sources */,
 				981C7893225F95900009FC3E /* ChatNavigationButtonController.swift in Sources */,
 				98003D4922872C1800592D55 /* URLCodable.swift in Sources */,

--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -124,11 +124,13 @@
 		9838F28E227B771F00744EDD /* IDStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9838F28D227B771F00744EDD /* IDStore.swift */; };
 		98401AF521FB79F400064DAE /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98401AF421FB79F400064DAE /* ChatViewController.swift */; };
 		98401AF721FBCA1100064DAE /* ChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98401AF621FBCA1100064DAE /* ChatInputView.swift */; };
+		9841B477237E9239000A4922 /* AnnotationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9841B476237E9239000A4922 /* AnnotationController.swift */; };
 		9843FAA1236CD7F000457930 /* NetworkDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9843FAA0236CD7F000457930 /* NetworkDataProvider.swift */; };
 		9843FAA3236CDC0D00457930 /* NetworkOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9843FAA2236CDC0D00457930 /* NetworkOperatorTests.swift */; };
 		9843FAA5236CDC6E00457930 /* MockNetworkDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9843FAA4236CDC6E00457930 /* MockNetworkDataProvider.swift */; };
 		9844438123429354005468B2 /* UIView+Autolayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9844438023429354005468B2 /* UIView+Autolayout.swift */; };
 		9853B50F237E0E8D00F46AB6 /* MKMapView+Register.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9853B50E237E0E8D00F46AB6 /* MKMapView+Register.swift */; };
+		9853B511237E101300F46AB6 /* BikeAnnotationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9853B510237E101300F46AB6 /* BikeAnnotationController.swift */; };
 		985E94B9220796CB00AA991B /* NavigationOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985E94B8220796CB00AA991B /* NavigationOverlayViewController.swift */; };
 		986749F8235230CB00BF5D6E /* Crypto in Frameworks */ = {isa = PBXBuildFile; productRef = 986749F7235230CB00BF5D6E /* Crypto */; };
 		98790021222DA7E600880334 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98790020222DA7E600880334 /* AppDelegate.swift */; };
@@ -311,11 +313,13 @@
 		9838F28D227B771F00744EDD /* IDStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDStore.swift; sourceTree = "<group>"; };
 		98401AF421FB79F400064DAE /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
 		98401AF621FBCA1100064DAE /* ChatInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInputView.swift; sourceTree = "<group>"; };
+		9841B476237E9239000A4922 /* AnnotationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationController.swift; sourceTree = "<group>"; };
 		9843FAA0236CD7F000457930 /* NetworkDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkDataProvider.swift; sourceTree = "<group>"; };
 		9843FAA2236CDC0D00457930 /* NetworkOperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkOperatorTests.swift; sourceTree = "<group>"; };
 		9843FAA4236CDC6E00457930 /* MockNetworkDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkDataProvider.swift; sourceTree = "<group>"; };
 		9844438023429354005468B2 /* UIView+Autolayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Autolayout.swift"; sourceTree = "<group>"; };
 		9853B50E237E0E8D00F46AB6 /* MKMapView+Register.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MKMapView+Register.swift"; sourceTree = "<group>"; };
+		9853B510237E101300F46AB6 /* BikeAnnotationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeAnnotationController.swift; sourceTree = "<group>"; };
 		985E94B8220796CB00AA991B /* NavigationOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationOverlayViewController.swift; sourceTree = "<group>"; };
 		98790020222DA7E600880334 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		987E3BD72368C6E100BAEFE7 /* MemoryDataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemoryDataStore.swift; sourceTree = "<group>"; };
@@ -550,7 +554,7 @@
 				9485A92D23756A3B006DC7B5 /* ContentState */,
 				989F9FEF21C7E5FC00E71085 /* Rules */,
 				985E94BC220891F200AA991B /* Social */,
-				9822A16721F24CA7007F5994 /* MapViewController.swift */,
+				9841B475237E9229000A4922 /* Map */,
 				982DA8D92203842D00E2A51B /* SettingsViewController.swift */,
 				985E94B8220796CB00AA991B /* NavigationOverlayViewController.swift */,
 			);
@@ -727,6 +731,16 @@
 				9838F28D227B771F00744EDD /* IDStore.swift */,
 			);
 			name = DeviceID;
+			sourceTree = "<group>";
+		};
+		9841B475237E9229000A4922 /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				9822A16721F24CA7007F5994 /* MapViewController.swift */,
+				9853B510237E101300F46AB6 /* BikeAnnotationController.swift */,
+				9841B476237E9239000A4922 /* AnnotationController.swift */,
+			);
+			name = Map;
 			sourceTree = "<group>";
 		};
 		985E94BC220891F200AA991B /* Social */ = {
@@ -1057,6 +1071,7 @@
 				9823712623781D53009D6F05 /* SimulationNetworkDataProvider.swift in Sources */,
 				98401AF721FBCA1100064DAE /* ChatInputView.swift in Sources */,
 				94FCBD28226C57CA00F93F94 /* UITableViewController+FooterSize.swift in Sources */,
+				9853B511237E101300F46AB6 /* BikeAnnotationController.swift in Sources */,
 				9491720D23009EB3008B98AD /* APIRequest.swift in Sources */,
 				988B12AD22A271FE0010FAED /* Logger.swift in Sources */,
 				94FCBD35226C57FA00F93F94 /* ThemeController.swift in Sources */,
@@ -1085,6 +1100,7 @@
 				98F225262368D1B100EE8BD9 /* ChatMessageTableViewCell.swift in Sources */,
 				98E7338A220394E7005F311F /* SettingsSwitchTableViewCell.swift in Sources */,
 				9822A17221F3349F007F5994 /* Preferences.swift in Sources */,
+				9841B477237E9239000A4922 /* AnnotationController.swift in Sources */,
 				989F9FFE21C8035500E71085 /* ApiResponse.swift in Sources */,
 				9491720F23009ED0008B98AD /* TwitterRequest.swift in Sources */,
 				982DA8C921FF65F700E2A51B /* Tweet.swift in Sources */,

--- a/CriticalMass/AnnotationController.swift
+++ b/CriticalMass/AnnotationController.swift
@@ -1,0 +1,28 @@
+//
+//  AnnotationController.swift
+//  CriticalMaps
+//
+//  Created by Leonard Thomas on 15.11.19.
+//  Copyright © 2019 Pokus Labs. All rights reserved.
+//
+
+import MapKit
+
+class AnnotationController<T: IdentifiableAnnnotation, K: MKAnnotationView>: NSObject {
+    var mapView: MKMapView
+    let annotationType = T.self
+    let annotationViewType = K.self
+
+    required init(mapView: MKMapView) {
+        self.mapView = mapView
+        super.init()
+    }
+
+    open func setup() {
+        mapView.register(annotationType: BikeAnnoationView.self)
+    }
+    
+    open func prepareAnnotationView(annotation:T) -> K? {
+        return nil
+    }
+}

--- a/CriticalMass/AnnotationController.swift
+++ b/CriticalMass/AnnotationController.swift
@@ -8,21 +8,15 @@
 
 import MapKit
 
-class AnnotationController<T: IdentifiableAnnnotation, K: MKAnnotationView>: NSObject {
+class AnnotationController<T: IdentifiableAnnnotation, K: MKAnnotationView> {
     var mapView: MKMapView
     let annotationType = T.self
     let annotationViewType = K.self
 
     required init(mapView: MKMapView) {
         self.mapView = mapView
-        super.init()
-    }
-
-    open func setup() {
-        mapView.register(annotationType: BikeAnnoationView.self)
+        setup()
     }
     
-    open func prepareAnnotationView(annotation:T) -> K? {
-        return nil
-    }
+    open func setup() {}
 }

--- a/CriticalMass/BikeAnnotationController.swift
+++ b/CriticalMass/BikeAnnotationController.swift
@@ -12,8 +12,6 @@ class BikeAnnotation: IdentifiableAnnnotation {}
 
 class BikeAnnotationController: AnnotationController<BikeAnnotation, BikeAnnoationView> {
     public override func setup() {
-        mapView.register(annotationType: BikeAnnoationView.self)
-
         NotificationCenter.default.addObserver(self, selector: #selector(positionsDidChange(notification:)), name: Notification.positionOthersChanged, object: nil)
     }
 
@@ -42,9 +40,5 @@ class BikeAnnotationController: AnnotationController<BikeAnnotation, BikeAnnoati
 
         // remove annotations that no longer exist
         mapView.removeAnnotations(unmatchedAnnotations)
-    }
-    
-    override func prepareAnnotationView(annotation: BikeAnnotation) -> BikeAnnoationView? {
-        mapView.dequeueReusableAnnotationView(ofType: BikeAnnoationView.self, with: annotation)
     }
 }

--- a/CriticalMass/BikeAnnotationController.swift
+++ b/CriticalMass/BikeAnnotationController.swift
@@ -1,0 +1,50 @@
+//
+//  BikeAnnotationController.swift
+//  CriticalMaps
+//
+//  Created by Leonard Thomas on 14.11.19.
+//  Copyright © 2019 Pokus Labs. All rights reserved.
+//
+
+import MapKit
+
+class BikeAnnotation: IdentifiableAnnnotation {}
+
+class BikeAnnotationController: AnnotationController<BikeAnnotation, BikeAnnoationView> {
+    public override func setup() {
+        mapView.register(annotationType: BikeAnnoationView.self)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(positionsDidChange(notification:)), name: Notification.positionOthersChanged, object: nil)
+    }
+
+    @objc private func positionsDidChange(notification: Notification) {
+        guard let response = notification.object as? ApiResponse else { return }
+        display(locations: response.locations)
+    }
+
+    private func display(locations: [String: Location]) {
+        guard LocationManager.accessPermission == .authorized else {
+            return
+        }
+        var unmatchedLocations = locations
+        var unmatchedAnnotations: [MKAnnotation] = []
+        // update existing annotations
+        mapView.annotations.compactMap { $0 as? BikeAnnotation }.forEach { annotation in
+            if let location = unmatchedLocations[annotation.identifier] {
+                annotation.location = location
+                unmatchedLocations.removeValue(forKey: annotation.identifier)
+            } else {
+                unmatchedAnnotations.append(annotation)
+            }
+        }
+        let annotations = unmatchedLocations.map { BikeAnnotation(location: $0.value, identifier: $0.key) }
+        mapView.addAnnotations(annotations)
+
+        // remove annotations that no longer exist
+        mapView.removeAnnotations(unmatchedAnnotations)
+    }
+    
+    override func prepareAnnotationView(annotation: BikeAnnotation) -> BikeAnnoationView? {
+        mapView.dequeueReusableAnnotationView(ofType: BikeAnnoationView.self, with: annotation)
+    }
+}

--- a/CriticalMass/BikeAnnotationController.swift
+++ b/CriticalMass/BikeAnnotationController.swift
@@ -22,6 +22,7 @@ class BikeAnnotationController: AnnotationController<BikeAnnotation, BikeAnnoati
 
     private func display(locations: [String: Location]) {
         guard LocationManager.accessPermission == .authorized else {
+            Logger.log(.info, log: .map, "Bike annotations cannot be displayed because no GPS Access permission granted", parameter: LocationManager.accessPermission.rawValue)
             return
         }
         var unmatchedLocations = locations

--- a/CriticalMass/LocationProvider.swift
+++ b/CriticalMass/LocationProvider.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum LocationProviderPermission {
+public enum LocationProviderPermission: String {
     case authorized
     case denied
     case disabled

--- a/CriticalMass/Logger.swift
+++ b/CriticalMass/Logger.swift
@@ -14,6 +14,9 @@ extension OSLog {
 
     @available(OSX 10.12, *)
     static let viewManagement = OSLog(subsystem: subsystem, category: "viewManagement")
+    
+    @available(OSX 10.12, *)
+    static let map = OSLog(subsystem: subsystem, category: "Map")
 }
 
 class Logger {

--- a/CriticalMass/MKMapView+Register.swift
+++ b/CriticalMass/MKMapView+Register.swift
@@ -15,9 +15,9 @@ extension MKAnnotationView {
 }
 
 extension MKMapView {
-    func register<T: MKAnnotationView>(annotationType: T.Type) {
+    func register<T: MKAnnotationView>(annotationViewType: T.Type) {
         if #available(iOS 11.0, *) {
-            register(annotationType, forAnnotationViewWithReuseIdentifier: annotationType.reuseIdentifier)
+            register(annotationViewType, forAnnotationViewWithReuseIdentifier: annotationViewType.reuseIdentifier)
         }
     }
 

--- a/CriticalMass/MKMapView+Register.swift
+++ b/CriticalMass/MKMapView+Register.swift
@@ -21,7 +21,6 @@ extension MKMapView {
         }
     }
 
-    
     func dequeueReusableAnnotationView<T: MKAnnotationView>(ofType annotationType: T.Type, for indexPath: IndexPath? = nil, with annotation: MKAnnotation) -> T {
         let annotationView: T
         if #available(iOS 11.0, *) {
@@ -32,6 +31,4 @@ extension MKMapView {
         }
         return annotationView
     }
-
 }
-

--- a/CriticalMass/MKMapView+Register.swift
+++ b/CriticalMass/MKMapView+Register.swift
@@ -1,0 +1,37 @@
+//
+//  MKMapView+Register.swift
+//  CriticalMaps
+//
+//  Created by Leonard Thomas on 14.11.19.
+//  Copyright © 2019 Pokus Labs. All rights reserved.
+//
+
+import MapKit
+
+extension MKAnnotationView {
+    fileprivate class var reuseIdentifier: String {
+        return String(describing: self)
+    }
+}
+
+extension MKMapView {
+    func register<T: MKAnnotationView>(annotationType: T.Type) {
+        if #available(iOS 11.0, *) {
+            register(annotationType, forAnnotationViewWithReuseIdentifier: annotationType.reuseIdentifier)
+        }
+    }
+
+    
+    func dequeueReusableAnnotationView<T: MKAnnotationView>(ofType annotationType: T.Type, for indexPath: IndexPath? = nil, with annotation: MKAnnotation) -> T {
+        let annotationView: T
+        if #available(iOS 11.0, *) {
+            annotationView = dequeueReusableAnnotationView(withIdentifier: annotationType.reuseIdentifier, for: annotation) as! T
+        } else {
+            annotationView = dequeueReusableAnnotationView(withIdentifier: annotationType.reuseIdentifier) as? T ?? T()
+            annotationView.annotation = annotation
+        }
+        return annotationView
+    }
+
+}
+

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -11,50 +11,56 @@ import UIKit
 class MapViewController: UIViewController {
     private let themeController: ThemeController!
     private var tileRenderer: MKTileOverlayRenderer?
-
+    
     init(themeController: ThemeController) {
         self.themeController = themeController
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     // MARK: Properties
-
+    
+    private lazy var annotationController: [AnnotationController] = {
+        [BikeAnnotationController(mapView: self.mapView)]
+    }()
+    
     private let nightThemeOverlay = DarkModeMapOverlay()
     public lazy var followMeButton: UserTrackingButton = {
         let button = UserTrackingButton(mapView: mapView)
         return button
     }()
-
+    
     public var bottomContentOffset: CGFloat = 0 {
         didSet {
             mapView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: bottomContentOffset, right: 0)
         }
     }
-
+    
     private var mapView = MKMapView(frame: .zero)
-
+    
     private let gpsDisabledOverlayView: BlurryOverlayView = {
         let view = BlurryOverlayView.fromNib()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         title = String.mapTitle
         configureNotifications()
         configureTileRenderer()
         configureMapView()
         condfigureGPSDisabledOverlayView()
-
+        
+        annotationController.forEach { $0.setup() }
+        
         setNeedsStatusBarAppearanceUpdate()
     }
-
+    
     private func configureTileRenderer() {
         guard themeController.currentTheme == .dark else {
             if #available(iOS 13.0, *) {
@@ -62,14 +68,14 @@ class MapViewController: UIViewController {
             }
             return
         }
-
+        
         if #available(iOS 13.0, *) {
             overrideUserInterfaceStyle = .dark
         } else {
             addTileRenderer()
         }
     }
-
+    
     private func condfigureGPSDisabledOverlayView() {
         let gpsDisabledOverlayView = self.gpsDisabledOverlayView
         gpsDisabledOverlayView.set(title: String.mapLayerInfoTitle, message: String.mapLayerInfo)
@@ -79,92 +85,63 @@ class MapViewController: UIViewController {
             gpsDisabledOverlayView.heightAnchor.constraint(equalTo: view.heightAnchor),
             gpsDisabledOverlayView.widthAnchor.constraint(equalTo: view.widthAnchor),
         ])
-
+        
         updateGPSDisabledOverlayVisibility()
     }
-
+    
     private func configureNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(positionsDidChange(notification:)), name: Notification.positionOthersChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReceiveInitialLocation(notification:)), name: Notification.initialGpsDataReceived, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateGPSDisabledOverlayVisibility), name: Notification.observationModeChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Notification.themeDidChange, object: nil)
     }
-
+    
     private func configureMapView() {
         view.addSubview(mapView)
         mapView.addLayoutsSameSizeAndOrigin(in: view)
-        mapView.register(annotationType: BikeAnnoationView.self)
         mapView.showsPointsOfInterest = false
         mapView.delegate = self
         mapView.showsUserLocation = true
     }
-
-    private func display(locations: [String: Location]) {
-        guard LocationManager.accessPermission == .authorized else {
-            return
-        }
-        var unmatchedLocations = locations
-        var unmatchedAnnotations: [MKAnnotation] = []
-        // update existing annotations
-        mapView.annotations.compactMap { $0 as? IdentifiableAnnnotation }.forEach { annotation in
-            if let location = unmatchedLocations[annotation.identifier] {
-                annotation.location = location
-                unmatchedLocations.removeValue(forKey: annotation.identifier)
-            } else {
-                unmatchedAnnotations.append(annotation)
-            }
-        }
-        let annotations = unmatchedLocations.map { IdentifiableAnnnotation(location: $0.value, identifier: $0.key) }
-        mapView.addAnnotations(annotations)
-
-        // remove annotations that no longer exist
-        mapView.removeAnnotations(unmatchedAnnotations)
-    }
     
     // GPS Disabled Overlay
-
+    
     @objc func didTapGPSDisabledOverlayButton() {
         UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
     }
-
+    
     @objc func updateGPSDisabledOverlayVisibility() {
         gpsDisabledOverlayView.isHidden = LocationManager.accessPermission != .denied
     }
-
+    
     // MARK: Notifications
-
+    
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return themeController.currentTheme.style.statusBarStyle
     }
-
+    
     @objc private func themeDidChange() {
         let theme = themeController.currentTheme
         guard theme == .dark else {
-                if #available(iOS 13.0, *) {
+            if #available(iOS 13.0, *) {
                 overrideUserInterfaceStyle = .light
-                } else {
-                    removeTileRenderer()
-                }
+            } else {
+                removeTileRenderer()
+            }
             return
         }
         configureTileRenderer()
     }
-
+    
     private func removeTileRenderer() {
         tileRenderer = nil
         mapView.removeOverlay(nightThemeOverlay)
     }
-
+    
     private func addTileRenderer() {
         tileRenderer = MKTileOverlayRenderer(tileOverlay: nightThemeOverlay)
         mapView.addOverlay(nightThemeOverlay, level: .aboveRoads)
     }
-
-    @objc private func positionsDidChange(notification: Notification) {
-        guard let response = notification.object as? ApiResponse else { return }
-        display(locations: response.locations)
-    }
-
+    
     @objc func didReceiveInitialLocation(notification: Notification) {
         guard let location = notification.object as? Location else { return }
         let region = MKCoordinateRegion(center: CLLocationCoordinate2D(location), latitudinalMeters: 10000, longitudinalMeters: 10000)
@@ -175,19 +152,23 @@ class MapViewController: UIViewController {
 
 extension MapViewController: MKMapViewDelegate {
     // MARK: MKMapViewDelegate
-
+    
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
         guard annotation is MKUserLocation == false else {
             return nil
         }
+         
+        guard let matchingController = annotationController.first(where: { type(of: annotation) == $0.annotationType }) else {
+            return nil
+        }
 
-        return mapView.dequeueReusableAnnotationView(ofType: BikeAnnoationView.self, with: annotation)
+        return matchingController.prepareAnnotationView(annotation: unsafeDowncast(annotation, to: matchingController.annotationType))
     }
-
+    
     func mapView(_: MKMapView, didChange mode: MKUserTrackingMode, animated _: Bool) {
         followMeButton.currentMode = UserTrackingButton.Mode(mode)
     }
-
+    
     func mapView(_: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
         guard let renderer = self.tileRenderer else {
             return MKOverlayRenderer(overlay: overlay)

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -56,7 +56,9 @@ class MapViewController: UIViewController {
         configureMapView()
         condfigureGPSDisabledOverlayView()
         
-        annotationController.forEach { $0.setup() }
+        annotationController
+            .map{ $0.annotationViewType }
+            .forEach(mapView.register)
         
         setNeedsStatusBarAppearanceUpdate()
     }
@@ -161,8 +163,8 @@ extension MapViewController: MKMapViewDelegate {
         guard let matchingController = annotationController.first(where: { type(of: annotation) == $0.annotationType }) else {
             return nil
         }
-
-        return matchingController.prepareAnnotationView(annotation: unsafeDowncast(annotation, to: matchingController.annotationType))
+        
+        return mapView.dequeueReusableAnnotationView(ofType: matchingController.annotationViewType, with: annotation)
     }
     
     func mapView(_: MKMapView, didChange mode: MKUserTrackingMode, animated _: Bool) {

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -92,17 +92,8 @@ class MapViewController: UIViewController {
 
     private func configureMapView() {
         view.addSubview(mapView)
-        mapView.translatesAutoresizingMaskIntoConstraints = false
-        view.addConstraints([
-            NSLayoutConstraint(item: mapView, attribute: .width, relatedBy: .equal, toItem: view, attribute: .width, multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: mapView, attribute: .height, relatedBy: .equal, toItem: view, attribute: .height, multiplier: 1, constant: 1),
-            NSLayoutConstraint(item: mapView, attribute: .leading, relatedBy: .equal, toItem: view, attribute: .leading, multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: mapView, attribute: .top, relatedBy: .equal, toItem: view, attribute: .top, multiplier: 1, constant: 0),
-        ])
-
-        if #available(iOS 11.0, *) {
-            mapView.register(BikeAnnoationView.self, forAnnotationViewWithReuseIdentifier: BikeAnnoationView.identifier)
-        }
+        mapView.addLayoutsSameSizeAndOrigin(in: view)
+        mapView.register(annotationType: BikeAnnoationView.self)
         mapView.showsPointsOfInterest = false
         mapView.delegate = self
         mapView.showsUserLocation = true
@@ -129,6 +120,8 @@ class MapViewController: UIViewController {
         // remove annotations that no longer exist
         mapView.removeAnnotations(unmatchedAnnotations)
     }
+    
+    // GPS Disabled Overlay
 
     @objc func didTapGPSDisabledOverlayButton() {
         UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
@@ -187,14 +180,8 @@ extension MapViewController: MKMapViewDelegate {
         guard annotation is MKUserLocation == false else {
             return nil
         }
-        let annotationView: BikeAnnoationView
-        if #available(iOS 11.0, *) {
-            annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: BikeAnnoationView.identifier, for: annotation) as! BikeAnnoationView
-        } else {
-            annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: BikeAnnoationView.identifier) as? BikeAnnoationView ?? BikeAnnoationView()
-            annotationView.annotation = annotation
-        }
-        return annotationView
+
+        return mapView.dequeueReusableAnnotationView(ofType: BikeAnnoationView.self, with: annotation)
     }
 
     func mapView(_: MKMapView, didChange mode: MKUserTrackingMode, animated _: Bool) {

--- a/CriticalMass/UIView+Autolayout.swift
+++ b/CriticalMass/UIView+Autolayout.swift
@@ -27,10 +27,10 @@ extension UIView {
         translatesAutoresizingMaskIntoConstraints = false
         
         view.addConstraints([
-            NSLayoutConstraint(item: self, attribute: .width, relatedBy: .equal, toItem: view, attribute: .width, multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: self, attribute: .height, relatedBy: .equal, toItem: view, attribute: .height, multiplier: 1, constant: 1),
-            NSLayoutConstraint(item: self, attribute: .leading, relatedBy: .equal, toItem: view, attribute: .leading, multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: self, attribute: .top, relatedBy: .equal, toItem: view, attribute: .top, multiplier: 1, constant: 0),
+            heightAnchor.constraint(equalTo: view.heightAnchor),
+            widthAnchor.constraint(equalTo: view.widthAnchor),
+            leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topAnchor.constraint(equalTo: view.topAnchor)
         ])
     }
 }

--- a/CriticalMass/UIView+Autolayout.swift
+++ b/CriticalMass/UIView+Autolayout.swift
@@ -22,4 +22,15 @@ extension UIView {
             widthAnchor.constraint(equalToConstant: size.width)
         ])
     }
+    
+    func addLayoutsSameSizeAndOrigin(in view: UIView) {
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        view.addConstraints([
+            NSLayoutConstraint(item: self, attribute: .width, relatedBy: .equal, toItem: view, attribute: .width, multiplier: 1, constant: 0),
+            NSLayoutConstraint(item: self, attribute: .height, relatedBy: .equal, toItem: view, attribute: .height, multiplier: 1, constant: 1),
+            NSLayoutConstraint(item: self, attribute: .leading, relatedBy: .equal, toItem: view, attribute: .leading, multiplier: 1, constant: 0),
+            NSLayoutConstraint(item: self, attribute: .top, relatedBy: .equal, toItem: view, attribute: .top, multiplier: 1, constant: 0),
+        ])
+    }
 }


### PR DESCRIPTION
I moved Annotation specific logic out of MapViewController into its own controller as the current MapView infrastructure becomes hard to maintain if we add more logic to it in the future. 

If we wanna add more annotationTypes (Friends, events etc), we'll just need to create a new `AnnotationController` subclass  and add that to `private lazy var annotationController: [AnnotationController]` and the rest should work out of the box
  