### PR TITLE
Load initial after launching the App

### DIFF
--- a/CriticalMass/RequestManager.swift
+++ b/CriticalMass/RequestManager.swift
@@ -40,6 +40,9 @@ public class RequestManager {
         self.locationProvider = locationProvider
         self.networkLayer = networkLayer
         configureTimer(with: interval)
+        
+        // load initial data
+        updateData()
     }
 
     private func configureTimer(with interval: TimeInterval) {

--- a/CriticalMassTests/ChatManagerTests.swift
+++ b/CriticalMassTests/ChatManagerTests.swift
@@ -14,6 +14,8 @@ class ChatManagerTests: XCTestCase {
         let dataStore = MemoryDataStore()
         let requestManager = RequestManager(dataStore: dataStore, locationProvider: MockLocationProvider(), networkLayer: networkLayer, idProvider: MockIDProvider())
         let chatManager = ChatManager(requestManager: requestManager)
+        networkLayer.numberOfPostCalled = 0
+        networkLayer.numberOfGetCalled = 0
         return (chatManager, networkLayer, dataStore)
     }
 

--- a/CriticalMassTests/RequestManagerTests.swift
+++ b/CriticalMassTests/RequestManagerTests.swift
@@ -9,13 +9,18 @@
 import XCTest
 
 class RequestManagerTests: XCTestCase {
-    func setup(interval: TimeInterval, deviceId: String = "") -> (requestManager: RequestManager, locationProvider: MockLocationProvider, dataStore: MockDataStore, networkLayer: MockNetworkLayer) {
+    func setup(interval: TimeInterval, deviceId: String = "", resetRequestCountAfterSetup: Bool = true) -> (requestManager: RequestManager, locationProvider: MockLocationProvider, dataStore: MockDataStore, networkLayer: MockNetworkLayer) {
         let dataStore = MockDataStore()
         let locationProvider = MockLocationProvider()
         let networkLayer = MockNetworkLayer()
         let mockIDProvider = MockIDProvider()
         mockIDProvider.mockID = deviceId
-        return (RequestManager(dataStore: dataStore, locationProvider: locationProvider, networkLayer: networkLayer, interval: interval, idProvider: mockIDProvider), locationProvider, dataStore, networkLayer)
+        let result = (RequestManager(dataStore: dataStore, locationProvider: locationProvider, networkLayer: networkLayer, interval: interval, idProvider: mockIDProvider), locationProvider, dataStore, networkLayer)
+        if resetRequestCountAfterSetup {
+            networkLayer.numberOfGetCalled = 0
+            networkLayer.numberOfPostCalled = 0
+        }
+        return result
     }
 
     func testNoRequestForActiveRequests() {
@@ -85,5 +90,10 @@ class RequestManagerTests: XCTestCase {
         XCTAssertEqual(testSetup.networkLayer.numberOfGetCalled, 0)
         XCTAssertEqual(testSetup.networkLayer.numberOfPostCalled, 1)
         XCTAssertEqual(testSetup.networkLayer.lastUsedPostBody as! [String: AnyHashable], expectedBody)
+    }
+    
+    func testLoadInitialData() {
+        let setup = self.setup(interval: 100000, resetRequestCountAfterSetup: false)
+        XCTAssertEqual(setup.networkLayer.numberOfRequests, 1)
     }
 }


### PR DESCRIPTION
Not sure if that regressed or always been that way but currently we request the data for the first time after 12 seconds. So the user will see an empty map for 12 seconds. The only workaround currently is opening chat