### PR TITLE
Forbid Arbitrary Loads

### DIFF
--- a/CriticalMass/CriticalMaps-Info.plist
+++ b/CriticalMass/CriticalMaps-Info.plist
@@ -30,11 +30,6 @@
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>This app needs the access to be able to share your location with other Critical Maps users.</string>
 	<key>NSLocationAlwaysUsageDescription</key>


### PR DESCRIPTION
Disabling ATS can cause a rejection of Apple and should be prevented. The code was added 2015 as a fix for iOS 9. As the minimum deployment target is iOS 10 now, I think it's not needed for anything anymore. I tested the app and it looks like everything is still working. 