### PR TITLE
Add userDefaults to extension

### DIFF
--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		949BD4B323CB4BEB00EA7BA4 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 949BD4B123CB4BEB00EA7BA4 /* README.md */; };
 		949BEF552237CAEC009AE6DF /* RoundableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949BEF542237CAEC009AE6DF /* RoundableImageView.swift */; };
 		94A95EB32287F81100FD5FDB /* NoContentMessageLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A95EB22287F81100FD5FDB /* NoContentMessageLabel.swift */; };
+		94AF230923D6D64600267E87 /* DateAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AF230823D6D64600267E87 /* DateAdditionsTests.swift */; };
 		94CCC8B623D0583D000CCE2A /* Date+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CCC8B523D0583D000CCE2A /* Date+Additions.swift */; };
 		94CCC8B823D0587F000CCE2A /* UserDefaults+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CCC8B723D0587F000CCE2A /* UserDefaults+Additions.swift */; };
 		94CF086019BDEAF2009FFF43 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94CF085F19BDEAF2009FFF43 /* Foundation.framework */; };
@@ -287,6 +288,7 @@
 		949BD4B123CB4BEB00EA7BA4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		949BEF542237CAEC009AE6DF /* RoundableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundableImageView.swift; sourceTree = "<group>"; };
 		94A95EB22287F81100FD5FDB /* NoContentMessageLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoContentMessageLabel.swift; sourceTree = "<group>"; };
+		94AF230823D6D64600267E87 /* DateAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateAdditionsTests.swift; sourceTree = "<group>"; };
 		94CCC8B523D0583D000CCE2A /* Date+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Additions.swift"; sourceTree = "<group>"; };
 		94CCC8B723D0587F000CCE2A /* UserDefaults+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Additions.swift"; sourceTree = "<group>"; };
 		94CF085C19BDEAF2009FFF43 /* CriticalMaps.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CriticalMaps.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -781,21 +783,22 @@
 		94CF087E19BDEAF2009FFF43 /* CriticalMassTests */ = {
 			isa = PBXGroup;
 			children = (
-				98003D5F2287301000592D55 /* FollowURLObjectTests.swift */,
-				943ABD9422781F0200B7F07C /* ThemeControllerTests.swift */,
-				943ABD9322781F0200B7F07C /* ThemeStoreTests.swift */,
-				94CF087F19BDEAF2009FFF43 /* Supporting Files */,
-				9822A15621EE0956007F5994 /* RuleTests.swift */,
-				9822A16321F113DC007F5994 /* RequestManagerTests.swift */,
 				9822A16521F11519007F5994 /* AppDataStoreTests.swift */,
 				9804178F21FCA2B40077D419 /* ChatManagerTests.swift */,
-				982DA8D521FFAC0D00E2A51B /* TwitterManagerTests.swift */,
-				98C13289227F05E700291FCA /* IDStoreTests.swift */,
-				981C92082288B47F00391FA9 /* TestHelper.swift */,
+				94AF230823D6D64600267E87 /* DateAdditionsTests.swift */,
+				98003D5F2287301000592D55 /* FollowURLObjectTests.swift */,
 				98ED2FDC22919BDD007F8A92 /* FriendsVerificationControllerTests.swift */,
+				98C13289227F05E700291FCA /* IDStoreTests.swift */,
 				98329A2222D3CADB00A157EE /* KeychainHelperTests.swift */,
-				9810C383229831720011F718 /* RatingHelperTests.swift */,
 				9843FAA2236CDC0D00457930 /* NetworkOperatorTests.swift */,
+				9810C383229831720011F718 /* RatingHelperTests.swift */,
+				9822A16321F113DC007F5994 /* RequestManagerTests.swift */,
+				9822A15621EE0956007F5994 /* RuleTests.swift */,
+				94CF087F19BDEAF2009FFF43 /* Supporting Files */,
+				981C92082288B47F00391FA9 /* TestHelper.swift */,
+				943ABD9422781F0200B7F07C /* ThemeControllerTests.swift */,
+				943ABD9322781F0200B7F07C /* ThemeStoreTests.swift */,
+				982DA8D521FFAC0D00E2A51B /* TwitterManagerTests.swift */,
 			);
 			path = CriticalMassTests;
 			sourceTree = "<group>";
@@ -1333,6 +1336,7 @@
 				9810C384229831720011F718 /* RatingHelperTests.swift in Sources */,
 				9822A15721EE0956007F5994 /* RuleTests.swift in Sources */,
 				98C1328A227F05E700291FCA /* IDStoreTests.swift in Sources */,
+				94AF230923D6D64600267E87 /* DateAdditionsTests.swift in Sources */,
 				75E26994235A4BA5000F2D0A /* MockThemeController.swift in Sources */,
 				9822A16421F113DC007F5994 /* RequestManagerTests.swift in Sources */,
 				9843FAA3236CDC0D00457930 /* NetworkOperatorTests.swift in Sources */,

--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		949BD4B323CB4BEB00EA7BA4 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 949BD4B123CB4BEB00EA7BA4 /* README.md */; };
 		949BEF552237CAEC009AE6DF /* RoundableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949BEF542237CAEC009AE6DF /* RoundableImageView.swift */; };
 		94A95EB32287F81100FD5FDB /* NoContentMessageLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A95EB22287F81100FD5FDB /* NoContentMessageLabel.swift */; };
+		94CCC8B623D0583D000CCE2A /* Date+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CCC8B523D0583D000CCE2A /* Date+Additions.swift */; };
+		94CCC8B823D0587F000CCE2A /* UserDefaults+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CCC8B723D0587F000CCE2A /* UserDefaults+Additions.swift */; };
 		94CF086019BDEAF2009FFF43 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94CF085F19BDEAF2009FFF43 /* Foundation.framework */; };
 		94CF086219BDEAF2009FFF43 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94CF086119BDEAF2009FFF43 /* CoreGraphics.framework */; };
 		94CF086419BDEAF2009FFF43 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94CF086319BDEAF2009FFF43 /* UIKit.framework */; };
@@ -285,6 +287,8 @@
 		949BD4B123CB4BEB00EA7BA4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		949BEF542237CAEC009AE6DF /* RoundableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundableImageView.swift; sourceTree = "<group>"; };
 		94A95EB22287F81100FD5FDB /* NoContentMessageLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoContentMessageLabel.swift; sourceTree = "<group>"; };
+		94CCC8B523D0583D000CCE2A /* Date+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Additions.swift"; sourceTree = "<group>"; };
+		94CCC8B723D0587F000CCE2A /* UserDefaults+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Additions.swift"; sourceTree = "<group>"; };
 		94CF085C19BDEAF2009FFF43 /* CriticalMaps.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CriticalMaps.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		94CF085F19BDEAF2009FFF43 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		94CF086119BDEAF2009FFF43 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -516,6 +520,7 @@
 		9460B769225A6E9B00786E27 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				94CCC8B423D0582A000CCE2A /* Extensions */,
 				21859FAD2352B6AA00B942AA /* AsyncOperation.swift */,
 				3F997954239D9DD5006DB96B /* Feature.swift */,
 				94D4016E229F20F6001524CC /* FontMetrics.swift */,
@@ -696,6 +701,15 @@
 				98205F682207937100122EDA /* AppController.swift */,
 			);
 			name = Root;
+			sourceTree = "<group>";
+		};
+		94CCC8B423D0582A000CCE2A /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				94CCC8B523D0583D000CCE2A /* Date+Additions.swift */,
+				94CCC8B723D0587F000CCE2A /* UserDefaults+Additions.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 		94CF085319BDEAF2009FFF43 = {
@@ -1224,6 +1238,7 @@
 				98F225262368D1B100EE8BD9 /* ChatMessageTableViewCell.swift in Sources */,
 				98E7338A220394E7005F311F /* SettingsSwitchTableViewCell.swift in Sources */,
 				98003D5E22872E4500592D55 /* QRCodeView.swift in Sources */,
+				94CCC8B623D0583D000CCE2A /* Date+Additions.swift in Sources */,
 				9822A17221F3349F007F5994 /* Preferences.swift in Sources */,
 				9841B477237E9239000A4922 /* AnnotationController.swift in Sources */,
 				989F9FFE21C8035500E71085 /* ApiResponse.swift in Sources */,
@@ -1235,6 +1250,7 @@
 				98AAD08F2337FF90001519C7 /* ManageFriendsViewController.swift in Sources */,
 				9843FAA1236CD7F000457930 /* NetworkDataProvider.swift in Sources */,
 				9409274D22841E160034E46B /* String+LocalizedStrings.swift in Sources */,
+				94CCC8B823D0587F000CCE2A /* UserDefaults+Additions.swift in Sources */,
 				982DA8CB21FF673500E2A51B /* TwitterViewController.swift in Sources */,
 				940643D023071F3200AB1BCB /* ErrorHandler.swift in Sources */,
 				21859FAC2352AE5200B942AA /* UpdateDataOperation.swift in Sources */,

--- a/CriticalMass/AppDataStore.swift
+++ b/CriticalMass/AppDataStore.swift
@@ -22,7 +22,7 @@ public class AppDataStore: DataStore {
     private var lastKnownResponse: ApiResponse?
 
     public var userName: String {
-        get { userDefaults.username }
+        get { userDefaults.username ?? UIDevice.current.name }
         set { userDefaults.username = newValue }
     }
 

--- a/CriticalMass/AppDataStore.swift
+++ b/CriticalMass/AppDataStore.swift
@@ -9,7 +9,7 @@ import CoreData
 import UIKit
 
 public class AppDataStore: DataStore {
-    private var userDefaults: UserDefaults
+    private let userDefaults: UserDefaults
 
     public init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
@@ -22,15 +22,8 @@ public class AppDataStore: DataStore {
     private var lastKnownResponse: ApiResponse?
 
     public var userName: String {
-        set {
-            if !newValue.isEmpty {
-                userDefaults.set(newValue, forKey: #function)
-            }
-        }
-
-        get {
-            userDefaults.string(forKey: #function) ?? UIDevice.current.name
-        }
+        get { userDefaults.username }
+        set { userDefaults.username = newValue }
     }
 
     public func update(with response: ApiResponse) {

--- a/CriticalMass/ChatManager.swift
+++ b/CriticalMass/ChatManager.swift
@@ -12,6 +12,7 @@ class ChatManager {
     private var cachedMessages: [ChatMessage]?
     private let requestManager: RequestManager
     private let errorHandler: ErrorHandler
+    private let defaults: UserDefaults
 
     var updateMessagesCallback: (([ChatMessage]) -> Void)?
     var updateUnreadMessagesCountCallback: ((UInt) -> Void)?
@@ -24,10 +25,19 @@ class ChatManager {
         }
     }
 
-    init(requestManager: RequestManager, errorHandler: ErrorHandler = PrintErrorHandler()) {
+    init(
+        requestManager: RequestManager, 
+        defaults: UserDefaults = .standard,
+        errorHandler: ErrorHandler = PrintErrorHandler()
+    ) {
+        self.defaults = defaults
         self.requestManager = requestManager
         self.errorHandler = errorHandler
-        NotificationCenter.default.addObserver(self, selector: #selector(didReceiveMessages(notification:)), name: Notification.chatMessagesReceived, object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didReceiveMessages(notification:)),
+            name: Notification.chatMessagesReceived, object: nil
+        )
     }
 
     @objc private func didReceiveMessages(notification: Notification) {
@@ -35,7 +45,7 @@ class ChatManager {
         cachedMessages = Array(response.chatMessages.values).sorted(by: { (a, b) -> Bool in
             a.timestamp > b.timestamp
         })
-        unreadMessagesCount = UInt(cachedMessages?.lazy.filter { $0.timestamp > Preferences.lastMessageReadTimeInterval }.count ?? 0)
+        unreadMessagesCount = UInt(cachedMessages?.lazy.filter { $0.timestamp > self.defaults.lastMessageReadTimeInterval }.count ?? 0)
         updateMessagesCallback?(cachedMessages ?? [])
     }
 
@@ -66,7 +76,7 @@ class ChatManager {
 
     public func markAllMessagesAsRead() {
         if let timestamp = cachedMessages?.first?.timestamp {
-            Preferences.lastMessageReadTimeInterval = timestamp
+            defaults.lastMessageReadTimeInterval = timestamp
         }
         unreadMessagesCount = 0
     }

--- a/CriticalMass/ChatManager.swift
+++ b/CriticalMass/ChatManager.swift
@@ -26,7 +26,7 @@ class ChatManager {
     }
 
     init(
-        requestManager: RequestManager, 
+        requestManager: RequestManager,
         defaults: UserDefaults = .standard,
         errorHandler: ErrorHandler = PrintErrorHandler()
     ) {

--- a/CriticalMass/Date+Additions.swift
+++ b/CriticalMass/Date+Additions.swift
@@ -4,6 +4,20 @@
 import Foundation
 
 public extension Date {
-    static var yesterday: Date { Date(timeInterval: -86400, since: .now) }
+    static var yesterday: Date {
+        let dateComponents = DateComponents(day: -1)
+        return Calendar.current.date(byAdding: dateComponents, to: .now)!
+    }
+
     static var now: Date { Date() }
+
+    /// Get a component representation of todays Date as Int.
+    /// - Parameter keyPath:
+    /// - Returns: DateComponent representation as Int. Returns 0 when component is not available
+    static func getCurrent(_ keyPath: KeyPath<DateComponents, Int?>) -> Int {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day], from: .now)
+        let component = components[keyPath: keyPath] ?? 0
+        return component
+    }
 }

--- a/CriticalMass/Date+Additions.swift
+++ b/CriticalMass/Date+Additions.swift
@@ -1,0 +1,9 @@
+//
+//  CriticalMaps
+
+import Foundation
+
+public extension Date {
+    static var yesterday: Date { Date(timeInterval: -86400, since: .now) }
+    static var now: Date { Date() }
+}

--- a/CriticalMass/Date+Additions.swift
+++ b/CriticalMass/Date+Additions.swift
@@ -4,9 +4,9 @@
 import Foundation
 
 public extension Date {
-    static var yesterday: Date {
+    static func yesterday(_ date: Date = .now) -> Date {
         let dateComponents = DateComponents(day: -1)
-        return Calendar.current.date(byAdding: dateComponents, to: .now)!
+        return Calendar.current.date(byAdding: dateComponents, to: date)!
     }
 
     static var now: Date { Date() }
@@ -14,9 +14,12 @@ public extension Date {
     /// Get a component representation of todays Date as Int.
     /// - Parameter keyPath:
     /// - Returns: DateComponent representation as Int. Returns 0 when component is not available
-    static func getCurrent(_ keyPath: KeyPath<DateComponents, Int?>) -> Int {
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.year, .month, .day], from: .now)
+    static func getCurrent(
+        _ keyPath: KeyPath<DateComponents, Int?>,
+        _ date: Date = .now,
+        _ calendar: Calendar = .current
+    ) -> Int {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
         let component = components[keyPath: keyPath] ?? 0
         return component
     }

--- a/CriticalMass/NextRideRequest.swift
+++ b/CriticalMass/NextRideRequest.swift
@@ -44,16 +44,3 @@ struct NextRideRequest: APIRequestDefining {
         return try decoder.decode(ResponseDataType.self, from: data)
     }
 }
-
-private extension Date {
-    /// Get a component representation of todays Date as Int.
-    /// - Parameter keyPath:
-    /// - Returns: DateComponent representation as Int. Returns 0 when component is not available
-    static func getCurrent(_ keyPath: KeyPath<DateComponents, Int?>) -> Int {
-        let date = Date()
-        let calendar = Calendar.current
-        let components = calendar.dateComponents([.year, .month, .day], from: date)
-        let component = components[keyPath: keyPath] ?? 0
-        return component
-    }
-}

--- a/CriticalMass/Preferences.swift
+++ b/CriticalMass/Preferences.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import UIKit
 
 class ObservationModePreferenceStore: Switchable {
     private let defaults: UserDefaults

--- a/CriticalMass/Preferences.swift
+++ b/CriticalMass/Preferences.swift
@@ -6,40 +6,27 @@
 //
 
 import Foundation
+import UIKit
 
 class ObservationModePreferenceStore: Switchable {
-    private let defaultsKey = "observationMode"
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
     }
 
-    private func save(_ isEnabled: Bool) {
-        defaults.set(isEnabled, forKey: defaultsKey)
-        NotificationCenter.default.post(name: Notification.observationModeChanged, object: isEnabled)
-    }
-
-    private func load() -> Bool? {
-        defaults.bool(forKey: defaultsKey)
-    }
-
     var isEnabled: Bool {
-        get {
-            load() ?? false
-        } set {
-            save(newValue)
+        get { defaults.observationMode }
+        set {
+            defaults.observationMode = newValue
+            NotificationCenter.default.post(name: Notification.observationModeChanged, object: newValue)
         }
     }
 }
 
-class Preferences {
+struct Preferences {
     static var lastMessageReadTimeInterval: Double {
-        get {
-            UserDefaults.standard.double(forKey: #function)
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: #function)
-        }
+        get { UserDefaults.standard.lastMessageReadTimeInterval }
+        set { UserDefaults.standard.lastMessageReadTimeInterval = newValue }
     }
 }

--- a/CriticalMass/Preferences.swift
+++ b/CriticalMass/Preferences.swift
@@ -23,10 +23,3 @@ class ObservationModePreferenceStore: Switchable {
         }
     }
 }
-
-struct Preferences {
-    static var lastMessageReadTimeInterval: Double {
-        get { UserDefaults.standard.lastMessageReadTimeInterval }
-        set { UserDefaults.standard.lastMessageReadTimeInterval = newValue }
-    }
-}

--- a/CriticalMass/RatingHelper.swift
+++ b/CriticalMass/RatingHelper.swift
@@ -17,17 +17,19 @@ public protocol RatingRequest {
 }
 
 public class RatingHelper {
-    public var daysUntilPrompt = 1
-    public var usesUntilPrompt = 5
+    private let daysUntilPrompt = 1
+    private let usesUntilPrompt = 5
 
     private let userDefaults: UserDefaults
     private let ratingRequest: RatingRequest.Type
     private let currentVersion: String
 
     @available(iOS 10.3, *)
-    public init(defaults: UserDefaults = UserDefaults.standard,
-                ratingRequest: RatingRequest.Type = SKStoreReviewController.self,
-                currentVersion: String = Bundle.main.versionNumber + Bundle.main.buildNumber) {
+    public init(
+        defaults: UserDefaults = .standard,
+        ratingRequest: RatingRequest.Type = SKStoreReviewController.self,
+        currentVersion: String = Bundle.main.versionNumber + Bundle.main.buildNumber
+    ) {
         userDefaults = defaults
         self.ratingRequest = ratingRequest
         self.currentVersion = currentVersion
@@ -44,77 +46,37 @@ public class RatingHelper {
     private func onEvent() {
         resetCounterIfneeded()
         increaseDaysCounterIfNeeded()
-        usesCounter += 1
+        userDefaults.usesCounter += 1
         rateIfNeeded()
     }
 
-    private var lastDayUsed: Date? {
-        set {
-            userDefaults.set(newValue?.timeIntervalSince1970, forKey: #function)
-        }
-        get {
-            guard userDefaults.value(forKey: #function) != nil else {
-                return nil
-            }
-            let timeInterval = userDefaults.double(forKey: #function)
-            return Date(timeIntervalSince1970: timeInterval)
-        }
-    }
-
-    private var daysCounter: Int {
-        set {
-            userDefaults.set(newValue, forKey: #function)
-        }
-        get {
-            userDefaults.integer(forKey: #function)
-        }
-    }
-
-    private var usesCounter: Int {
-        set {
-            userDefaults.set(newValue, forKey: #function)
-        }
-        get {
-            userDefaults.integer(forKey: #function)
-        }
-    }
-
-    private var lastRatedVersion: String? {
-        set {
-            userDefaults.set(newValue, forKey: #function)
-        }
-        get {
-            userDefaults.string(forKey: #function)
-        }
-    }
-
     private var shouldPromptRatingRequest: Bool {
-        daysCounter >= daysUntilPrompt &&
-            usesCounter >= usesUntilPrompt &&
-            currentVersion != lastRatedVersion
+        userDefaults.daysCounter >= daysUntilPrompt &&
+            userDefaults.usesCounter >= usesUntilPrompt &&
+            currentVersion != userDefaults.lastRatedVersion
     }
 
     private func increaseDaysCounterIfNeeded() {
         let now = Date()
-        if let date = lastDayUsed {
+        if let date = userDefaults.lastDayUsed {
             let components = Calendar.current.dateComponents([.day], from: date, to: now)
-            daysCounter += components.day ?? 0
+            userDefaults.daysCounter += components.day ?? 0
         }
-        lastDayUsed = now
+        userDefaults.lastDayUsed = now
     }
 
     private func rateIfNeeded() {
         if shouldPromptRatingRequest {
             ratingRequest.requestReview()
-            lastRatedVersion = currentVersion
+            userDefaults.lastRatedVersion = currentVersion
         }
     }
 
     private func resetCounterIfneeded() {
         // we set the counter to 0 if we installed a new version
-        if usesCounter != 0, lastRatedVersion == currentVersion {
-            usesCounter = 0
-            daysCounter = 0
+        if userDefaults.usesCounter != 0, userDefaults.lastRatedVersion == currentVersion {
+            userDefaults.usesCounter = 0
+            userDefaults.daysCounter = 0
         }
     }
 }

--- a/CriticalMass/Theme.swift
+++ b/CriticalMass/Theme.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-enum Theme: Int {
+enum Theme: String {
     case light
     case dark
 
@@ -30,6 +30,17 @@ enum Theme: Int {
             return LightTheme()
         case .dark:
             return DarkTheme()
+        }
+    }
+}
+
+extension Theme {
+    init?(_ themeString: String?) {
+        guard let theme = themeString?.lowercased() else { return nil }
+        switch theme {
+        case "light": self = .light
+        case "dark": self = .dark
+        default: return nil
         }
     }
 }

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -24,15 +24,12 @@ class ThemeController {
     }
 
     private func loadTheme() -> Theme {
-        guard let theme = store.load() else {
-            if #available(iOS 13.0, *) {
-                let theme = Theme(userInterfaceStyle: UITraitCollection.current.userInterfaceStyle)
-                return theme
-            } else {
-                return .light
-            }
+        if #available(iOS 13.0, *) {
+            let theme = Theme(userInterfaceStyle: UITraitCollection.current.userInterfaceStyle)
+            return theme
+        } else {
+            return store.load() ?? .light
         }
-        return theme
     }
 
     /// Applies the current selected theme to the apps UI components
@@ -162,9 +159,7 @@ class ThemeController {
 
 extension ThemeController: Switchable {
     var isEnabled: Bool {
-        get {
-            currentTheme == .dark
-        }
+        get { currentTheme == .dark }
         set {
             changeTheme(to: newValue ? .dark : .light)
             // This is a workaround to wait for the switch animation to finish before updating the UI

--- a/CriticalMass/ThemeStore.swift
+++ b/CriticalMass/ThemeStore.swift
@@ -14,7 +14,6 @@ protocol ThemeStorable {
 }
 
 class ThemeSelectionStore: ThemeStorable {
-    private let defaultsKey = "theme"
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -25,16 +24,13 @@ class ThemeSelectionStore: ThemeStorable {
     ///
     /// - Parameter themeSelection: The Theme that will be saved.
     func save(_ themeSelection: Theme) {
-        defaults.set(themeSelection.rawValue, forKey: defaultsKey)
+        defaults.theme = themeSelection.rawValue
     }
 
     /// Fetches saved theme from the UserDefaults
     ///
-    /// - Returns: Saved Theme from a previous session.
+    /// - Returns: Saved theme from a previous session or nil if this is the first start.
     func load() -> Theme? {
-        guard let storedTheme = defaults.object(forKey: defaultsKey) as? Int else {
-            return nil
-        }
-        return Theme(rawValue: storedTheme)
+        Theme(defaults.theme)
     }
 }

--- a/CriticalMass/UserDefaults+Additions.swift
+++ b/CriticalMass/UserDefaults+Additions.swift
@@ -1,0 +1,73 @@
+//
+//  CriticalMaps
+
+import Foundation
+import UIKit
+
+extension UserDefaults {
+    public static func makeClearedInstance(
+        for functionName: StaticString = #function,
+        inFile fileName: StaticString = #file
+    ) -> UserDefaults {
+        let className = "\(fileName)".split(separator: ".")[0]
+        let testName = "\(functionName)".split(separator: "(")[0]
+        let suiteName = "de.pokuslabs.criticalmassberlin.test.\(className).\(testName)"
+
+        let defaults = self.init(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}
+
+extension UserDefaults {
+    private enum Keys {
+        static let observationModeKey = "observationMode"
+        static let lastMessageReadTimeIntervalKey = "lastMessageReadTimeInterval"
+        static let themeKey = "theme"
+        static let lastDayUsedKey = "lastDayUsed"
+        static let daysCounterKey = "daysCounter"
+        static let usesCounterKey = "usesCounter"
+        static let lastRatedVersionKey = "lastRatedVersion"
+        static let userNameKey = "username"
+    }
+
+    public var username: String {
+        set { set(newValue, forKey: Keys.userNameKey) }
+        get { string(forKey: Keys.userNameKey) ?? UIDevice.current.name }
+    }
+
+    public var observationMode: Bool {
+        set { set(newValue, forKey: Keys.observationModeKey) }
+        get { bool(forKey: Keys.observationModeKey) }
+    }
+
+    public var lastMessageReadTimeInterval: Double {
+        set { set(newValue, forKey: Keys.lastMessageReadTimeIntervalKey) }
+        get { double(forKey: Keys.lastMessageReadTimeIntervalKey) }
+    }
+
+    public var theme: Int {
+        set { set(newValue, forKey: Keys.themeKey) }
+        get { integer(forKey: Keys.themeKey) }
+    }
+
+    public var lastDayUsed: Date? {
+        set { set(newValue, forKey: Keys.lastDayUsedKey) }
+        get { object(forKey: Keys.lastDayUsedKey) as? Date }
+    }
+
+    public var daysCounter: Int {
+        set { set(newValue, forKey: Keys.daysCounterKey) }
+        get { integer(forKey: Keys.daysCounterKey) }
+    }
+
+    public var usesCounter: Int {
+        set { set(newValue, forKey: Keys.usesCounterKey) }
+        get { integer(forKey: Keys.usesCounterKey) }
+    }
+
+    public var lastRatedVersion: String? {
+        set { set(newValue, forKey: Keys.lastRatedVersionKey) }
+        get { string(forKey: Keys.lastRatedVersionKey) }
+    }
+}

--- a/CriticalMass/UserDefaults+Additions.swift
+++ b/CriticalMass/UserDefaults+Additions.swift
@@ -31,9 +31,9 @@ extension UserDefaults {
         static let userNameKey = "username"
     }
 
-    public var username: String {
+    public var username: String? {
         set { set(newValue, forKey: Keys.userNameKey) }
-        get { string(forKey: Keys.userNameKey) ?? UIDevice.current.name }
+        get { string(forKey: Keys.userNameKey) }
     }
 
     public var observationMode: Bool {

--- a/CriticalMass/UserDefaults+Additions.swift
+++ b/CriticalMass/UserDefaults+Additions.swift
@@ -46,9 +46,9 @@ extension UserDefaults {
         get { double(forKey: Keys.lastMessageReadTimeIntervalKey) }
     }
 
-    public var theme: Int {
+    public var theme: String? {
         set { set(newValue, forKey: Keys.themeKey) }
-        get { integer(forKey: Keys.themeKey) }
+        get { string(forKey: Keys.themeKey) }
     }
 
     public var lastDayUsed: Date? {

--- a/CriticalMassTests/AppDataStoreTests.swift
+++ b/CriticalMassTests/AppDataStoreTests.swift
@@ -11,10 +11,12 @@ import XCTest
 
 class AppDataStoreTests: XCTestCase {
     var sut: AppDataStore!
-    var userdefaults = UserDefaults(suiteName: "CriticalMaps-Tests")!
+    var userdefaults: UserDefaults!
 
     override func setUp() {
         super.setUp()
+
+        userdefaults = .makeClearedInstance()
 
         var feature = Feature.friends
         feature.isActive = true
@@ -27,7 +29,6 @@ class AppDataStoreTests: XCTestCase {
 
     override func tearDown() {
         sut = nil
-        userdefaults.removePersistentDomain(forName: "CriticalMaps-Tests")
         super.tearDown()
     }
 
@@ -164,12 +165,5 @@ class AppDataStoreTests: XCTestCase {
         XCTAssertNotEqual(sut.userName, newName)
         sut.userName = newName
         XCTAssertEqual(sut.userName, newName)
-    }
-
-    func testDontStoreEmptyUsername() {
-        let newName = ""
-        XCTAssertNotEqual(sut.userName, newName)
-        sut.userName = newName
-        XCTAssertNotEqual(sut.userName, newName)
     }
 }

--- a/CriticalMassTests/ChatManagerTests.swift
+++ b/CriticalMassTests/ChatManagerTests.swift
@@ -11,16 +11,18 @@ import XCTest
 class ChatManagerTests: XCTestCase {
     func getSetup() -> (chatManager: ChatManager, networkLayer: MockNetworkLayer, dataStore: DataStore) {
         let networkLayer = MockNetworkLayer()
-        let dataStore = AppDataStore()
+        let dataStore = AppDataStore(userDefaults: userDefaults)
         let requestManager = RequestManager(dataStore: dataStore, locationProvider: MockLocationProvider(), networkLayer: networkLayer, idProvider: MockIDProvider(), networkObserver: nil)
-        let chatManager = ChatManager(requestManager: requestManager)
+        let chatManager = ChatManager(requestManager: requestManager, defaults: userDefaults)
         return (chatManager, networkLayer, dataStore)
     }
 
+    var userDefaults: UserDefaults!
+
     override func setUp() {
         super.setUp()
-
-        Preferences.lastMessageReadTimeInterval = 0
+        userDefaults = .makeClearedInstance()
+        userDefaults.lastMessageReadTimeInterval = 0
     }
 
     func testSendMessage() {
@@ -134,7 +136,7 @@ class ChatManagerTests: XCTestCase {
 
     func testMessagesUnreadCountWithExistingTimeStamp() {
         let setup = getSetup()
-        Preferences.lastMessageReadTimeInterval = 1
+        userDefaults.lastMessageReadTimeInterval = 1
         setup.dataStore.update(with: ApiResponse(locations: [:], chatMessages: ["1": ChatMessage(message: "Hello", timestamp: 1), "2": ChatMessage(message: "World", timestamp: 2)]))
         XCTAssertEqual(setup.chatManager.unreadMessagesCount, 1)
     }

--- a/CriticalMassTests/DateAdditionsTests.swift
+++ b/CriticalMassTests/DateAdditionsTests.swift
@@ -1,0 +1,41 @@
+//
+//  CriticalMapsTests
+
+@testable import CriticalMaps
+import XCTest
+
+class DateAdditionsTests: XCTestCase {
+    // 21. January 2020 06:52:21 GMT
+    let date = Date(timeIntervalSince1970: 1_579_589_541)
+
+    func testGetCurrentDayShouldReturnDayAs21() {
+        // when
+        let day = Date.getCurrent(\.day, date)
+        // then
+        XCTAssertEqual(day, 21)
+    }
+
+    func testGetCurrentMonthShouldReturnMonth1() {
+        // when
+        let month = Date.getCurrent(\.month, date)
+        // then
+        XCTAssertEqual(month, 1)
+    }
+
+    func testGetCurrentYearShouldReturnDayAs2020() {
+        // when
+        let year = Date.getCurrent(\.year, date)
+        // then
+        XCTAssertEqual(year, 2020)
+    }
+
+    func testYesterDayShouldReturnEqualGeneratedDateFromTimestamp() {
+        // given
+        // 20. January 2020 06:52:21 GMT
+        let yesterdayFromTimestamp = Date(timeIntervalSince1970: 1_579_503_141)
+        // when
+        let yesterday = Date.yesterday(date)
+        // then
+        XCTAssertEqual(yesterday, yesterdayFromTimestamp)
+    }
+}

--- a/CriticalMassTests/RatingHelperTests.swift
+++ b/CriticalMassTests/RatingHelperTests.swift
@@ -47,7 +47,7 @@ class RatingHelperTests: XCTestCase {
 
     func testRequestAfterFiveLaunchesOnNextDay() {
         // mock app used yesterday
-        userdefaults.lastDayUsed = .yesterday
+        userdefaults.lastDayUsed = .yesterday()
 
         execute(times: 5, ratingHelper.onLaunch())
         XCTAssertEqual(MockRatingRequest.requestCounter, 1)
@@ -55,7 +55,7 @@ class RatingHelperTests: XCTestCase {
 
     func testNoRequestIfVersionAlreadyRated() {
         // mock app used yesterday
-        userdefaults.lastDayUsed = .yesterday
+        userdefaults.lastDayUsed = .yesterday()
 
         // mock version already rated
         userdefaults.lastRatedVersion = Bundle.main.versionNumber + Bundle.main.buildNumber
@@ -66,7 +66,7 @@ class RatingHelperTests: XCTestCase {
 
     func testRatingRequestAfterInstallingNewVersion() {
         // mock app used yesterday
-        userdefaults.lastDayUsed = .yesterday
+        userdefaults.lastDayUsed = .yesterday()
 
         // mock version already rated
         userdefaults.lastRatedVersion = Bundle.main.versionNumber + Bundle.main.buildNumber
@@ -75,7 +75,7 @@ class RatingHelperTests: XCTestCase {
         XCTAssertEqual(MockRatingRequest.requestCounter, 0)
 
         // mock app used yesterday
-        userdefaults.lastDayUsed = .yesterday
+        userdefaults.lastDayUsed = .yesterday()
 
         // mock new version  installed
         ratingHelper = RatingHelper(

--- a/CriticalMassTests/RatingHelperTests.swift
+++ b/CriticalMassTests/RatingHelperTests.swift
@@ -19,83 +19,70 @@ class MockRatingRequest: RatingRequest {
 
 class RatingHelperTests: XCTestCase {
     var ratingHelper: RatingHelper!
-    var userdefaults = UserDefaults(suiteName: "CriticalMaps-Tests")!
+    var userdefaults: UserDefaults!
 
     override func setUp() {
         super.setUp()
+        userdefaults = .makeClearedInstance()
         ratingHelper = RatingHelper(defaults: userdefaults, ratingRequest: MockRatingRequest.self)
     }
 
     override func tearDown() {
         ratingHelper = nil
         MockRatingRequest.requestCounter = 0
-        userdefaults.removePersistentDomain(forName: "CriticalMaps-Tests")
+        super.tearDown()
     }
 
     func testNoRequestOnFirstLaunch() {
-        ratingHelper.daysUntilPrompt = 1
-        ratingHelper.usesUntilPrompt = 5
-
         ratingHelper.onLaunch()
 
         XCTAssertEqual(MockRatingRequest.requestCounter, 0)
     }
 
     func testNoRequestAfterFiveLaunchesOnSameDay() {
-        ratingHelper.daysUntilPrompt = 1
-        ratingHelper.usesUntilPrompt = 5
-
         execute(times: 5, ratingHelper.onLaunch())
 
         XCTAssertEqual(MockRatingRequest.requestCounter, 0)
     }
 
     func testRequestAfterFiveLaunchesOnNextDay() {
-        ratingHelper.daysUntilPrompt = 1
-        ratingHelper.usesUntilPrompt = 5
-
         // mock app used yesterday
-        let yesterday = Date(timeInterval: -86400, since: Date()).timeIntervalSince1970
-        userdefaults.set(yesterday, forKey: "lastDayUsed")
+        userdefaults.lastDayUsed = .yesterday
 
         execute(times: 5, ratingHelper.onLaunch())
         XCTAssertEqual(MockRatingRequest.requestCounter, 1)
     }
 
     func testNoRequestIfVersionAlreadyRated() {
-        ratingHelper.daysUntilPrompt = 1
-        ratingHelper.usesUntilPrompt = 5
-
         // mock app used yesterday
-        let yesterday = Date(timeInterval: -86400, since: Date()).timeIntervalSince1970
-        userdefaults.set(yesterday, forKey: "lastDayUsed")
+        userdefaults.lastDayUsed = .yesterday
 
         // mock version already rated
-        userdefaults.set(Bundle.main.versionNumber + Bundle.main.buildNumber, forKey: "lastRatedVersion")
+        userdefaults.lastRatedVersion = Bundle.main.versionNumber + Bundle.main.buildNumber
 
         execute(times: 5, ratingHelper.onLaunch())
         XCTAssertEqual(MockRatingRequest.requestCounter, 0)
     }
 
     func testRatingRequestAfterInstallingNewVersion() {
-        ratingHelper.daysUntilPrompt = 1
-        ratingHelper.usesUntilPrompt = 5
-
         // mock app used yesterday
-        let yesterday = Date(timeInterval: -86400, since: Date()).timeIntervalSince1970
-        userdefaults.set(yesterday, forKey: "lastDayUsed")
+        userdefaults.lastDayUsed = .yesterday
 
         // mock version already rated
-        userdefaults.set(Bundle.main.versionNumber + Bundle.main.buildNumber, forKey: "lastRatedVersion")
+        userdefaults.lastRatedVersion = Bundle.main.versionNumber + Bundle.main.buildNumber
 
         execute(times: 5, ratingHelper.onLaunch())
         XCTAssertEqual(MockRatingRequest.requestCounter, 0)
 
         // mock app used yesterday
-        userdefaults.set(yesterday, forKey: "lastDayUsed")
+        userdefaults.lastDayUsed = .yesterday
 
         // mock new version  installed
-        ratingHelper = RatingHelper(defaults: userdefaults, ratingRequest: MockRatingRequest.self, currentVersion: "MockVersion")
+        ratingHelper = RatingHelper(
+            defaults: userdefaults,
+            ratingRequest: MockRatingRequest.self,
+            currentVersion: "MockVersion"
+        )
         execute(times: 5, ratingHelper.onLaunch())
         XCTAssertEqual(MockRatingRequest.requestCounter, 1)
     }

--- a/CriticalMassTests/ThemeStoreTests.swift
+++ b/CriticalMassTests/ThemeStoreTests.swift
@@ -10,17 +10,17 @@
 import XCTest
 
 class ThemeSelectionStoreTests: XCTestCase {
-    var sut: ThemeSelectionStore?
-    var userdefaults = UserDefaults(suiteName: "CriticalMaps-Tests")!
+    private var sut: ThemeSelectionStore?
+    private var userdefaults: UserDefaults!
 
     override func setUp() {
         super.setUp()
+        userdefaults = .makeClearedInstance()
         sut = ThemeSelectionStore(defaults: userdefaults)
     }
 
     override func tearDown() {
         sut = nil
-        userdefaults.removePersistentDomain(forName: "CriticalMaps-Tests")
         super.tearDown()
     }
 


### PR DESCRIPTION
What should have been a hands-on for PropertyWrappers turned out to be just a small refactoring for the use of `UserDefaults` in our app. Since they were kind of all around I wanted to centralize them and remove some boilerplate code. Using the Wrapper turned out to be not that handy with the current structure so I ended up streamlining the use of UserDefaults a bit

### Before merging the PR

- [x] If applicable, does the PR contain enough unit / UI tests?
- [ ] If applicable, did you add a before / after screenshot of the feature?
- [ ] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?
