### PR TITLE
Run tests on weekly update dependencies

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: master
 
       - name: Bump version
         run: bash update_dependencies.sh

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -20,6 +20,11 @@ jobs:
 
       - name: Smoke test
         run: bundle exec fastlane test
+      
+      - name: Clean up
+        run: |
+          rm -r -f vendor
+          rm -r -f .bundle
         
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -3,14 +3,27 @@ name: Update dependencies
 on:
   schedule:
   - cron: "0 0 * * 0"
+  pull_request:
+    branches:
+    - master
+env:
+    DEVELOPER_DIR: /Applications/Xcode_11.3.app/Contents/Developer
 
 jobs:
   createPullRequest:
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install Gem Dependencies
+        run: bundle install
+
       - name: Bump version
         run: bash update_dependencies.sh
+
+      - name: Smoke test
+        run: bundle exec fastlane test
+        
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -3,9 +3,7 @@ name: Update dependencies
 on:
   schedule:
   - cron: "0 0 * * 0"
-  pull_request:
-    branches:
-    - master
+  
 env:
     DEVELOPER_DIR: /Applications/Xcode_11.3.app/Contents/Developer
 
@@ -14,8 +12,6 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: master
 
       - name: Bump version
         run: bash update_dependencies.sh

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Gem Dependencies
-        run: bundle install
-
       - name: Bump version
         run: bash update_dependencies.sh
 

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -2,7 +2,7 @@
 
 execute_fastlane_snapshot() {
     echo "Updating fastlane snapshot"
-    bundle exec fastlane snapshot update
+    bundle exec fastlane snapshot update -f
 }
 
 check_bundle() {

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -29,7 +29,7 @@ run_swiftformat() {
     unzip -q swiftformat.zip
 
     echo "Forcefully copying the extracted swiftformat executble to bin"
-    yes | cp -rf nicklockwood*/CommandLineTool/swiftformat ../bin/
+    cp -rf nicklockwood*/CommandLineTool/swiftformat ../bin/
 
     echo "Removing the created swiftformat meta folder"
     cd ..
@@ -50,7 +50,7 @@ run_license_plist() {
     unzip -q portable_licenseplist.zip
 
     echo "Forcefully copying the extracted license-plist executble to bin"
-    yes | cp -rf ./license-plist ../bin/
+    cp -rf ./license-plist ../bin/
 
     echo "Removing the created license-plist meta folder"
     cd ..


### PR DESCRIPTION
I added a run of Unit tests to the update dependency action so that we can make sure that the code still compiles and works™️ because PR that use `secrets.GITHUB_TOKEN` don't trigger other CI Actions. Additionally, it will trigger an swiftformat and license-plist