### PR TITLE
Improved license-plist config on CI

### DIFF
--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -1136,7 +1136,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ $CONFIGURATION = \"Debug\" ]; then\n    $SOURCE_ROOT/bin/license-plist --package-path ./CriticalMaps.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.swift --output-path ./Settings.bundle\nfi\n";
+			shellScript = "if [ $CONFIGURATION = \"Debug\" ]; then\n    $SOURCE_ROOT/bin/license-plist --package-path $PROJECT_FILE_PATH/CriticalMaps.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.swift --output-path ./Settings.bundle\nfi\n";
 		};
 		946CDE07224130330059F892 /* 🔖 Set BuildNumber and VersionNumber in App Settings  */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/CriticalMass/BlurryFullscreenOverlayView.swift
+++ b/CriticalMass/BlurryFullscreenOverlayView.swift
@@ -72,7 +72,7 @@ class BlurryFullscreenOverlayView: UIView, IBConstructable {
     }
 
     private func updateGradient() {
-        guard let gradientLayer = self.layer as? CAGradientLayer else {
+        guard let gradientLayer = layer as? CAGradientLayer else {
             return
         }
 

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -233,7 +233,7 @@ extension MapViewController: MKMapViewDelegate {
     }
 
     func mapView(_: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
-        guard let renderer = self.tileRenderer else {
+        guard let renderer = tileRenderer else {
             return MKOverlayRenderer(overlay: overlay)
         }
         return renderer

--- a/CriticalMass/SocialViewController.swift
+++ b/CriticalMass/SocialViewController.swift
@@ -87,7 +87,7 @@ class SocialViewController: UIViewController, UIToolbarDelegate {
     private func configureSegmentedControl() {
         navigationItem.titleView = segmentedControl
         NSLayoutConstraint.activate([
-            segmentedControl.centerXAnchor.constraint(equalTo: self.navigationItem.titleView!.centerXAnchor),
+            segmentedControl.centerXAnchor.constraint(equalTo: navigationItem.titleView!.centerXAnchor),
             segmentedControl.heightAnchor.constraint(equalTo: navigationItem.titleView!.heightAnchor),
             segmentedControl.widthAnchor.constraint(equalToConstant: 180.0),
         ])

--- a/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -8,4 +8,4 @@ name: swift-snapshot-testing, nameSpecified: , owner: pointfreeco, version: 1.7.
 
 add-version-numbers: false
 
-LicensePlist Version: 2.9.0
+LicensePlist Version: 2.12.0


### PR DESCRIPTION
I added `$PROJECT_FILE_PATH` to specify the the Path to Package.Swift to hopefully fix the broken path on CI #234 

There are also some changes caused by an updated SwiftFormat version 