### PR TITLE
Fix entitlements

### DIFF
--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -1636,6 +1636,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 24;
@@ -1668,7 +1669,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = CriticalMaps/CriticalMaps.entitlements;
+				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 24;


### PR DESCRIPTION
## Thank you for your contribution! 

To be able to archive the build and upload to appstore, I needed to clear the field of Code Signing Entitlements:

<img width="771" alt="Screen Shot 2020-02-17 at 15 46 56" src="https://user-images.githubusercontent.com/1220469/74668502-42c2cf00-519d-11ea-99ee-cab44750bfeb.png">


## Checklist

### Before merging the PR

- [ ] If applicable, does the PR contain enough unit / UI tests?
- [ ] If applicable, did you add a before / after screenshot of the feature?
- [ ] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?
