### PR TITLE
Added Dependency Caching on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,26 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
+    - name: Cache SPM
+      uses: actions/cache@v1
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
+    - name: Cache Bundler
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
     - name: Install Gem Dependencies
-      run: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install
 
     - name: Run UnitTests
       run: bundle exec fastlane test
@@ -34,8 +52,26 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
+    - name: Cache SPM
+      uses: actions/cache@v1
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
+    - name: Cache Bundler
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
     - name: Install Gem Dependencies
-      run: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install
 
     - name: Run UITests
       run: bundle exec fastlane ui_test
@@ -54,8 +90,26 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
+    - name: Cache SPM
+      uses: actions/cache@v1
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
+    - name: Cache Bundler
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
     - name: Install Gem Dependencies
-      run: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install
 
     - name: Run SnapshotTests
       run: bundle exec fastlane snapshot_test
@@ -68,8 +122,26 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
+    - name: Cache SPM
+      uses: actions/cache@v1
+      with:
+        path: .build
+        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-spm-
+
+    - name: Cache Bundler
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
     - name: Install Gem Dependencies
-      run: bundle install
+      run: |
+        bundle config path vendor/bundle
+        bundle install
 
     - name: Run Swift Build
       run: swift build

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -13,6 +13,26 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache SPM
+        uses: actions/cache@v1
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Cache Bundler
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Define bundler config path
+        run: |
+          bundle config path vendor/bundle
+
       - name: Bump version
         run: bash update_dependencies.sh
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,12 +30,6 @@ platform :ios do
 
   desc 'Run unit tests'
   lane :test do
-
-    # Workaround to Resolve SPM Package Dependencies
-    # found here: https://github.com/fastlane/fastlane/issues/15454#issuecomment-543761561
-    # should be removed again, when Fastlane has fixed this
-    sh "cd .. && xcodebuild -resolvePackageDependencies"
-
     run_tests(
       device: 'iPhone 8',
       scheme: Scheme_UnitTests
@@ -44,8 +38,6 @@ platform :ios do
 
   desc 'Run snapshot tests'
   lane :snapshot_test do
-    sh "cd .. && xcodebuild -resolvePackageDependencies"
-    
     run_tests(
       scheme: Scheme_SnapshotTests,
       device: "iPhone 8"
@@ -54,8 +46,6 @@ platform :ios do
 
   desc 'Run UITests'
   lane :ui_test do
-    sh "cd .. && xcodebuild -resolvePackageDependencies"
-
     capture_ios_screenshots(
       app_identifier: AppIdentifier,
       configuration: 'Debug',


### PR DESCRIPTION
I added caching for SPM and Bundler dependencies #231 

I also removed the resolve dependency workaround from Fastlane since the new Fastlane version we are using, doesn't require the workaround anymore https://github.com/fastlane/fastlane/releases/tag/2.141.0