### PR TITLE
update fileheader comment & remove PL class prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 
 *.xccheckout
 
-CriticalMaps.xcodeproj
-
 *.mov
 Gfx/appstore/
 report.xml
@@ -14,3 +12,11 @@ fastlane/test_output
 ## Build generated
 build/
 .build
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+**/xcshareddata/WorkspaceSettings.xcsettings

--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -1005,7 +1005,7 @@
 		94CF085419BDEAF2009FFF43 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				CLASSPREFIX = PL;
+				CLASSPREFIX = "";
 				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "Pokus Labs";

--- a/CriticalMaps.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/CriticalMaps.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+	<string>
+// Created for ___PROJECTNAME___ in ___YEAR___</string>
+</dict>
+</plist>


### PR DESCRIPTION
The standard Xcode FILEHEADER is bloated, redundant and not (always) refactorsafe.
This PR adds a template for creating files in the project. 

The Header is up for discussion. First draft:
```swift
//
// Created for CriticalMaps in 2020

import Foundation
```

Also part of the PR is to remove the Class Prefix `PL` which is never used and probably a thing of the past 🦖