### PR TITLE
Fixed delay for displaying Annotations on Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog for Critical Maps iOS
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a Bug that caused a 12 second delay to display Riders on the Map after launching the App
+
 ### Updated
 
 - Cleaner BikeAnnotation appearance

--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		98C1327B227B8FE600291FCA /* IdentifiableAnnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C1327A227B8FE600291FCA /* IdentifiableAnnnotation.swift */; };
 		98C1328A227F05E700291FCA /* IDStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C13289227F05E700291FCA /* IDStoreTests.swift */; };
 		98C4BEA12218518B0060E701 /* UserTrackingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C4BEA02218518B0060E701 /* UserTrackingButton.swift */; };
+		98CE731924085E4A0088F7B4 /* IdentifiableAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CE731824085E4A0088F7B4 /* IdentifiableAnnotationTests.swift */; };
 		98DDF9E823D4F8E800E55BE7 /* MapOverlayErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DDF9E723D4F8E800E55BE7 /* MapOverlayErrorHandler.swift */; };
 		98E7338A220394E7005F311F /* SettingsSwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E73388220394E7005F311F /* SettingsSwitchTableViewCell.swift */; };
 		98E7338B220394E7005F311F /* SettingsSwitchTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98E73389220394E7005F311F /* SettingsSwitchTableViewCell.xib */; };
@@ -415,6 +416,7 @@
 		98C13288227F014000291FCA /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		98C13289227F05E700291FCA /* IDStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDStoreTests.swift; sourceTree = "<group>"; };
 		98C4BEA02218518B0060E701 /* UserTrackingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTrackingButton.swift; sourceTree = "<group>"; };
+		98CE731824085E4A0088F7B4 /* IdentifiableAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableAnnotationTests.swift; sourceTree = "<group>"; };
 		98DDF9E723D4F8E800E55BE7 /* MapOverlayErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapOverlayErrorHandler.swift; sourceTree = "<group>"; };
 		98E73388220394E7005F311F /* SettingsSwitchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSwitchTableViewCell.swift; sourceTree = "<group>"; };
 		98E73389220394E7005F311F /* SettingsSwitchTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SettingsSwitchTableViewCell.xib; sourceTree = "<group>"; };
@@ -802,6 +804,7 @@
 				943ABD9322781F0200B7F07C /* ThemeStoreTests.swift */,
 				982DA8D521FFAC0D00E2A51B /* TwitterManagerTests.swift */,
 				988BF2F823F35C7100594C3F /* TwitterRequestTests.swift */,
+				98CE731824085E4A0088F7B4 /* IdentifiableAnnotationTests.swift */,
 			);
 			path = CriticalMassTests;
 			sourceTree = "<group>";
@@ -1349,6 +1352,7 @@
 				9804179021FCA2B40077D419 /* ChatManagerTests.swift in Sources */,
 				98ED2FDD22919BDD007F8A92 /* FriendsVerificationControllerTests.swift in Sources */,
 				982DA8D621FFAC0D00E2A51B /* TwitterManagerTests.swift in Sources */,
+				98CE731924085E4A0088F7B4 /* IdentifiableAnnotationTests.swift in Sources */,
 				981C920A2288B49D00391FA9 /* TestHelper.swift in Sources */,
 				943ABD9522781F0200B7F07C /* ThemeStoreTests.swift in Sources */,
 				943ABD9622781F0200B7F07C /* ThemeControllerTests.swift in Sources */,

--- a/CriticalMass/IdentifiableAnnnotation.swift
+++ b/CriticalMass/IdentifiableAnnnotation.swift
@@ -19,7 +19,7 @@ class IdentifiableAnnnotation: MKPointAnnotation {
 
     var location: Location {
         didSet {
-            coordinate = CLLocationCoordinate2D(latitude: location.latitude, longitude: location.longitude)
+            coordinate = CLLocationCoordinate2D(location)
         }
     }
 
@@ -27,5 +27,6 @@ class IdentifiableAnnnotation: MKPointAnnotation {
         self.identifier = identifier
         self.location = location
         super.init()
+        coordinate = CLLocationCoordinate2D(location)
     }
 }

--- a/CriticalMass/SimulationNetworkDataProvider.swift
+++ b/CriticalMass/SimulationNetworkDataProvider.swift
@@ -18,7 +18,8 @@ class SimulationNetworkDataProvider: NetworkDataProvider {
 
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
         guard let url = request.url,
-            url.absoluteString == Constants.apiEndpoint else {
+            url.host == Constants.apiEndpoint,
+            url.path.isEmpty else {
             // only the base API is supported
             // We are falling back to the real NetworkDataProvider
             realNetworkDataProvider.dataTask(with: request, completionHandler: completionHandler)

--- a/CriticalMassTests/IdentifiableAnnotationTests.swift
+++ b/CriticalMassTests/IdentifiableAnnotationTests.swift
@@ -1,0 +1,27 @@
+//
+//  IdentifiableAnnotationTests.swift
+//  CriticalMapsTests
+//
+//  Created by Leonard Thomas on 27.02.20.
+//  Copyright © 2020 Pokus Labs. All rights reserved.
+//
+
+@testable import CriticalMaps
+import MapKit
+import XCTest
+
+extension CLLocationCoordinate2D: Equatable {
+    public static func == (lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Bool {
+        lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
+    }
+}
+
+class IdentifiableAnnotationTests: XCTestCase {
+    func testSetCoordianteOnInit() {
+        let location = Location(longitude: 42, latitude: 42, timestamp: 0, name: nil, color: nil)
+
+        let annotation = IdentifiableAnnnotation(location: location, identifier: "foo")
+
+        XCTAssertEqual(annotation.coordinate, CLLocationCoordinate2D(latitude: 42, longitude: 42))
+    }
+}


### PR DESCRIPTION
I was experiencing a delay for displaying Annotations but couldn't really find the issue but I accidentally found it while debugging #228 .

Because didSet won't get called on Init we are not setting the Coordinate Attribute which is needed to display the Annotation on a Map. So we were just showing Annotations that were shown before which als results in an empty Map for (minimum) 12 seconds after launching the App.

We should probably send out a new version with this fix