### PR TITLE
Bumped CI checkout actions to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Cache SPM
       uses: actions/cache@v1
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Cache SPM
       uses: actions/cache@v1
@@ -88,7 +88,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Cache SPM
       uses: actions/cache@v1
@@ -120,7 +120,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Cache SPM
       uses: actions/cache@v1


### PR DESCRIPTION
I noticed that the CI sometimes fails during the checkout step (https://github.com/criticalmaps/criticalmaps-ios/actions/runs/50668185). 
Updating to v2 hopefully helps