### PR TITLE
Animate CriticalMass Annotation when added to the map

### DIFF
--- a/CriticalMass/CMAnnotationView.swift
+++ b/CriticalMass/CMAnnotationView.swift
@@ -10,6 +10,7 @@ final class CMMarkerAnnotationView: MKMarkerAnnotationView {
     }
 
     private func commonInit() {
+        animatesWhenAdded = true
         markerTintColor = .white
         glyphImage = UIImage(named: "logo-m")
         canShowCallout = false


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📲 What

Set CriticalMass marker annotation `animatesWhenAdded` property true

## 🤔 Why

Adds a nice touch to it when the annotation is added to the map in the visible area