### PR TITLE
Added support for Full Page Screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for Critical Maps iOS
 
 ### Added
 
+- Fullpage screenshots of the Map
 - Showing next ride event notification and annotation view on the map.
 
 ### Fixed

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -82,6 +82,14 @@ class MapViewController: UIViewController {
         setNeedsStatusBarAppearanceUpdate()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if #available(iOS 13.0, *) {
+            view.window?.windowScene?.screenshotService?.delegate = self
+        }
+    }
+
     private func registerAnnotationViews() {
         annotationControllers
             .map { $0.annotationViewType }
@@ -271,5 +279,18 @@ extension MapViewController: MKMapViewDelegate {
             return MKOverlayRenderer(overlay: overlay)
         }
         return renderer
+    }
+}
+
+extension MapViewController: UIScreenshotServiceDelegate {
+    @available(iOS 13.0, *)
+    func screenshotService(_: UIScreenshotService, generatePDFRepresentationWithCompletion completionHandler: @escaping (Data?, Int, CGRect) -> Void) {
+        let data = UIGraphicsPDFRenderer(bounds: view.bounds).pdfData { context in
+            context.beginPage()
+
+            self.mapView.drawHierarchy(in: self.view.bounds, afterScreenUpdates: true)
+        }
+
+        completionHandler(data, 0, view.bounds)
     }
 }


### PR DESCRIPTION
## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

I added support for Full Page screenshots. For now, we'll just create a screenshot without any overlays (Thats the same what Apple maps does). Just that Map + Annotations. But we can also consider changing the size, removing UI or adding elements based on our needs cc. @zutrinken.

## 🔨 Technical Details

TIL there is an API to render map images  MKSnapshotter https://developer.apple.com/documentation/mapkit/mkmapsnapshotter. I decided to simply draw the view hierarchy for now, because MKSnapshotter doesn't support Annotations so we would need to add them manually to the context. But if we decide to change the aspect ratios of the screenshots (e.g. Showing a larger region, than the currently displayed region) MKSnapshotter might be useful, because it makes sure that all necessary tiles for the snapshots are loaded.

## 🤔 Why

Could be nice if user wanna share the Mass on social media without any overlays.
+ It's always nice to support system APIs when it makes sense 

## 👀 See

![Screenshots](https://user-images.githubusercontent.com/7677738/76547723-f746cc80-648d-11ea-8bd9-c198e3311e8e.gif)

