### PR TITLE
Add context menu or actionsheet to next event annotation

### DIFF
--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		949BEF552237CAEC009AE6DF /* RoundableImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949BEF542237CAEC009AE6DF /* RoundableImageView.swift */; };
 		949EBB1624102F1A00E4F93B /* String+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949EBB1524102F1A00E4F93B /* String+Additions.swift */; };
 		949EBB1824102F4900E4F93B /* StringAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949EBB1724102F4900E4F93B /* StringAdditionsTests.swift */; };
+		94A5FB8B242B88ED0037E5E3 /* AlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A5FB8A242B88ED0037E5E3 /* AlertPresenter.swift */; };
 		94A95EB32287F81100FD5FDB /* NoContentMessageLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A95EB22287F81100FD5FDB /* NoContentMessageLabel.swift */; };
 		94AF230923D6D64600267E87 /* DateAdditionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AF230823D6D64600267E87 /* DateAdditionsTests.swift */; };
 		94CCC8B623D0583D000CCE2A /* Date+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94CCC8B523D0583D000CCE2A /* Date+Additions.swift */; };
@@ -349,6 +350,7 @@
 		949BEF542237CAEC009AE6DF /* RoundableImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundableImageView.swift; sourceTree = "<group>"; };
 		949EBB1524102F1A00E4F93B /* String+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Additions.swift"; sourceTree = "<group>"; };
 		949EBB1724102F4900E4F93B /* StringAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringAdditionsTests.swift; sourceTree = "<group>"; };
+		94A5FB8A242B88ED0037E5E3 /* AlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPresenter.swift; sourceTree = "<group>"; };
 		94A95EB22287F81100FD5FDB /* NoContentMessageLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoContentMessageLabel.swift; sourceTree = "<group>"; };
 		94AF230823D6D64600267E87 /* DateAdditionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateAdditionsTests.swift; sourceTree = "<group>"; };
 		94CCC8B523D0583D000CCE2A /* Date+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Additions.swift"; sourceTree = "<group>"; };
@@ -600,8 +602,10 @@
 		9460B769225A6E9B00786E27 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				94A5FB8A242B88ED0037E5E3 /* AlertPresenter.swift */,
 				21859FAD2352B6AA00B942AA /* AsyncOperation.swift */,
 				944D5EF1240CDEF700993899 /* CoordinateObfuscator.swift */,
+				94CCC8B423D0582A000CCE2A /* Extensions */,
 				3F997954239D9DD5006DB96B /* Feature.swift */,
 				94D4016E229F20F6001524CC /* FontMetrics.swift */,
 				9460B76A225A6EB200786E27 /* FormatDisplay.swift */,
@@ -609,6 +613,7 @@
 				94FCBD26226C57CA00F93F94 /* IBConstructable.swift */,
 				98C1327A227B8FE600291FCA /* IdentifiableAnnnotation.swift */,
 				98329A1E22D3BEA000A157EE /* KeychainHelper.swift */,
+				9409274C22841E160034E46B /* L10n.swift */,
 				988B12AC22A271FE0010FAED /* Logger.swift */,
 				9444D7E12281686000DF44C0 /* NetworkActivityIndicatorHelper.swift */,
 				210367B9237AACC6001F2A84 /* NetworkObserver.swift */,
@@ -620,8 +625,6 @@
 				9409274A228322FC0034E46B /* TypeNameProtocol.swift */,
 				98003D4822872C1700592D55 /* URLCodable.swift */,
 				21859FB12352CBD300B942AA /* WaitOperation.swift */,
-				9409274C22841E160034E46B /* L10n.swift */,
-				94CCC8B423D0582A000CCE2A /* Extensions */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -1390,6 +1393,7 @@
 				944D5F01240CE07600993899 /* CMAnnotationView.swift in Sources */,
 				949BD4AF23CB481200EA7BA4 /* CriticalMassInApiHandler.swift in Sources */,
 				98DDF9E823D4F8E800E55BE7 /* MapOverlayErrorHandler.swift in Sources */,
+				94A5FB8B242B88ED0037E5E3 /* AlertPresenter.swift in Sources */,
 				9485A93523756A53006DC7B5 /* LoadingViewController.swift in Sources */,
 				9485A93A23756A71006DC7B5 /* ContentState.swift in Sources */,
 				944D5EF7240CDEF700993899 /* NextRideManager.swift in Sources */,

--- a/CriticalMass/AlertPresenter.swift
+++ b/CriticalMass/AlertPresenter.swift
@@ -1,0 +1,32 @@
+//
+// Created for CriticalMaps in 2020
+
+import UIKit
+
+final class AlertPresenter {
+    private var viewController: UIViewController? {
+        UIApplication.shared.keyWindow?.rootViewController
+    }
+
+    static let shared = AlertPresenter()
+
+    private init() {}
+
+    func presentAlert(
+        title: String?,
+        message: String? = nil,
+        preferredStyle: UIAlertController.Style,
+        actionData: [UIAlertAction],
+        isCancelable: Bool = false
+    ) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: preferredStyle)
+        actionData.forEach(alert.addAction(_:))
+        if isCancelable {
+            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+            alert.addAction(cancelAction)
+        }
+        onMain {
+            self.viewController?.present(alert, animated: true, completion: nil)
+        }
+    }
+}

--- a/CriticalMass/AppController.swift
+++ b/CriticalMass/AppController.swift
@@ -133,9 +133,12 @@ class AppController {
                 let followURLObject = try FollowURLObject.decode(from: url.absoluteString)
 
                 dataStore.add(friend: followURLObject.queryObject)
-                let alertController = UIAlertController(title: L10n.settingsAddFriendTitle, message: followURLObject.queryObject.name + " " + L10n.settingsAddFriendDescription, preferredStyle: .alert)
-                alertController.addAction(UIAlertAction(title: L10n.ok, style: .destructive, handler: nil))
-                rootViewController.present(alertController, animated: true, completion: nil)
+                AlertPresenter.shared.presentAlert(
+                    title: L10n.settingsAddFriendTitle,
+                    message: followURLObject.queryObject.name + " " + L10n.settingsAddFriendDescription,
+                    preferredStyle: .alert,
+                    actionData: [UIAlertAction(title: L10n.ok, style: .default, handler: nil)]
+                )
                 return true
             } catch {
                 // unknown or broken link

--- a/CriticalMass/CMAnnotationView.swift
+++ b/CriticalMass/CMAnnotationView.swift
@@ -5,6 +5,11 @@ import MapKit
 
 @available(iOS 11.0, *)
 final class CMMarkerAnnotationView: MKMarkerAnnotationView {
+    typealias EventClosure = () -> Void
+
+    var shareEventClosure: EventClosure?
+    var routeEventClosure: EventClosure?
+
     override func prepareForDisplay() {
         super.prepareForDisplay()
         commonInit()
@@ -15,6 +20,53 @@ final class CMMarkerAnnotationView: MKMarkerAnnotationView {
         markerTintColor = .white
         glyphImage = UIImage(named: "logo-m")
         canShowCallout = false
+
+        if #available(iOS 13.0, *) {
+            let interaction = UIContextMenuInteraction(delegate: self)
+            addInteraction(interaction)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension CMMarkerAnnotationView: UIContextMenuInteractionDelegate {
+    func contextMenuInteraction(_: UIContextMenuInteraction, configurationForMenuAtLocation _: CGPoint) -> UIContextMenuConfiguration? {
+        UIContextMenuConfiguration(identifier: nil, previewProvider: { MapSnapshotViewController() }) { _ in
+            self.makeContextMenu()
+        }
+    }
+
+    private func makeContextMenu() -> UIMenu {
+        let share = UIAction(title: L10n.menuShare, image: UIImage(systemName: "square.and.arrow.up")) { _ in
+//            self.shareEvent()
+            self.shareEventClosure?()
+        }
+        let route = UIAction(title: L10n.menuRoute, image: UIImage(systemName: "arrow.turn.up.right")) { _ in
+//            self.routeToEvent()
+            self.routeEventClosure?()
+        }
+        return UIMenu(title: L10n.menuTitle, children: [share, route])
+    }
+
+    class MapSnapshotViewController: UIViewController {
+        private let imageView = UIImageView()
+
+        override func loadView() {
+            view = imageView
+        }
+
+        init() {
+            super.init(nibName: nil, bundle: nil)
+            imageView.backgroundColor = .clear
+            imageView.clipsToBounds = true
+            imageView.contentMode = .scaleAspectFit
+            imageView.image = UIImage(named: "event-marker")!
+            preferredContentSize = CGSize(width: 200, height: 150)
+        }
+
+        required init?(coder _: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
     }
 }
 

--- a/CriticalMass/CMAnnotationView.swift
+++ b/CriticalMass/CMAnnotationView.swift
@@ -38,11 +38,9 @@ extension CMMarkerAnnotationView: UIContextMenuInteractionDelegate {
 
     private func makeContextMenu() -> UIMenu {
         let share = UIAction(title: L10n.menuShare, image: UIImage(systemName: "square.and.arrow.up")) { _ in
-//            self.shareEvent()
             self.shareEventClosure?()
         }
         let route = UIAction(title: L10n.menuRoute, image: UIImage(systemName: "arrow.turn.up.right")) { _ in
-//            self.routeToEvent()
             self.routeEventClosure?()
         }
         return UIMenu(title: L10n.menuTitle, children: [share, route])

--- a/CriticalMass/ChatViewController.swift
+++ b/CriticalMass/ChatViewController.swift
@@ -154,13 +154,12 @@ extension ChatViewController: ChatInputDelegate {
                 completionHandler?(true)
             case .failure:
                 completionHandler?(false)
-                let alert = UIAlertController(title: L10n.error,
-                                              message: L10n.chatSendError,
-                                              preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "Ok",
-                                              style: .default,
-                                              handler: nil))
-                self?.present(alert, animated: true)
+                AlertPresenter.shared.presentAlert(
+                    title: L10n.error,
+                    message: L10n.chatSendError,
+                    preferredStyle: .alert,
+                    actionData: [UIAlertAction(title: L10n.ok, style: .default, handler: nil)]
+                )
             }
         }
     }

--- a/CriticalMass/L10n.swift
+++ b/CriticalMass/L10n.swift
@@ -42,6 +42,10 @@ enum L10n {
     // ErrorState
     static let errorStateTitle = L10n.translate("errorState.title")
     static let errorStateMessage = L10n.translate("errorState.message")
+    // Map action items
+    static let menuTitle = L10n.translate("map.menu.title")
+    static let menuShare = L10n.translate("map.menu.share")
+    static let menuRoute = L10n.translate("map.menu.route")
 }
 
 extension L10n {

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -309,9 +309,7 @@ extension MapViewController: MKMapViewDelegate {
     }
 
     private func routeToEvent() {
-        nextRideManager.nextRide.flatMap {
-            $0.openInMaps()
-        }
+        nextRideManager.nextRide?.openInMaps()
     }
 
     private func shareEvent() {

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -298,19 +298,14 @@ extension MapViewController: MKMapViewDelegate {
     }
 
     @objc private func handleEventLongPress(_: Any) {
-        let alertController = UIAlertController(title: L10n.menuTitle, message: nil, preferredStyle: .actionSheet)
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in }
-        alertController.addAction(cancelAction)
-        let routeAction = UIAlertAction(title: L10n.menuRoute, style: .default) { _ in
-            self.routeToEvent()
-        }
-        alertController.addAction(routeAction)
-        let shareAction = UIAlertAction(title: L10n.menuShare, style: .default) { _ in
-            self.shareEvent()
-        }
-        alertController.addAction(shareAction)
-        present(alertController, animated: true)
-        UIAccessibility.post(notification: .announcement, argument: nil)
+        let routeAction = UIAlertAction(title: L10n.menuRoute, style: .default) { _ in self.routeToEvent() }
+        let shareAction = UIAlertAction(title: L10n.menuShare, style: .default) { _ in self.shareEvent() }
+        AlertPresenter.shared.presentAlert(
+            title: L10n.menuTitle,
+            preferredStyle: .actionSheet,
+            actionData: [routeAction, shareAction],
+            isCancelable: true
+        )
     }
 
     private func routeToEvent() {

--- a/CriticalMass/Ride.swift
+++ b/CriticalMass/Ride.swift
@@ -27,6 +27,31 @@ extension Ride {
 
     var titleAndTime: String {
         let titleWithoutDate = title.removedDatePattern()
-        return "\(titleWithoutDate)\n\(dateTime.humanReadableDate) - \(dateTime.humanReadableTime)"
+        return """
+        \(titleWithoutDate)
+        \(dateTime.humanReadableDate) - \(dateTime.humanReadableTime)
+        """
+    }
+
+    var shareMessage: String {
+        guard let location = location else {
+            return titleAndTime
+        }
+        return """
+        \(titleAndTime)
+        \(location)
+        """
+    }
+}
+
+import MapKit
+extension Ride {
+    func openInMaps(_ options: [String: Any] = [
+        MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDefault
+    ]) {
+        let placemark = MKPlacemark(coordinate: coordinate, addressDictionary: nil)
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.name = location
+        mapItem.openInMaps(launchOptions: options)
     }
 }

--- a/CriticalMass/en.lproj/Localizable.strings
+++ b/CriticalMass/en.lproj/Localizable.strings
@@ -39,6 +39,15 @@
 "map.title" = "Critical Maps";
 
 /* No comment provided by engineer. */
+"map.menu.title" = "Next event";
+
+/* No comment provided by engineer. */
+"map.menu.share" = "Share";
+
+/* No comment provided by engineer. */
+"map.menu.route" = "Route";
+
+/* No comment provided by engineer. */
 "ok" = "OK";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📲 What

Add `UIMenu` support for iOS 13 and a `UILongPressGestureRecognizer` for < iOS13 to add some context to the Critical Mass Annotation.

* also adds an AlertPresenter to consolidate alert presenting. Please excuse cause not really part of this task

## 🤔 Why

To better integrate in the OS and to add some functionality to the Event annotation

## 👀 See

#### iOS 13
<img width="518" alt="Screenshot 2020-03-25 at 11 33 08" src="https://user-images.githubusercontent.com/14075359/77535715-61eb0580-6e9b-11ea-9465-417e9c2f9959.png">

#### iOS 10-12
<img width="487" alt="Screenshot 2020-03-25 at 11 30 36" src="https://user-images.githubusercontent.com/14075359/77535711-60b9d880-6e9b-11ea-97fb-ef4d0e53fba7.png">

## ♿️ Accessibility 

- [x] Sends UIAccessability notification when actionSheet appears
