### PR TITLE
Added syntatic sugar to some sequence methods

### DIFF
--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -188,6 +188,8 @@
 		9844438123429354005468B2 /* UIView+Autolayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9844438023429354005468B2 /* UIView+Autolayout.swift */; };
 		985E94B9220796CB00AA991B /* NavigationOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985E94B8220796CB00AA991B /* NavigationOverlayViewController.swift */; };
 		98707DFB24167A480045B811 /* FormatDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98707DFA24167A480045B811 /* FormatDisplayTests.swift */; };
+		9878D4CD243CAF0F00F79FD6 /* TypeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9878D4CC243CAF0F00F79FD6 /* TypeUtils.swift */; };
+		9878D4CF243CAF4700F79FD6 /* TypeUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9878D4CE243CAF4700F79FD6 /* TypeUtilsTests.swift */; };
 		98790021222DA7E600880334 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98790020222DA7E600880334 /* AppDelegate.swift */; };
 		987C57A623A4EAF80060499B /* MapInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987C57A423A4EAF80060499B /* MapInfoView.swift */; };
 		987C57A723A4EAF80060499B /* MapInfoView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 987C57A523A4EAF80060499B /* MapInfoView.xib */; };
@@ -446,6 +448,8 @@
 		9853B50E237E0E8D00F46AB6 /* MKMapView+Register.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MKMapView+Register.swift"; sourceTree = "<group>"; };
 		985E94B8220796CB00AA991B /* NavigationOverlayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationOverlayViewController.swift; sourceTree = "<group>"; };
 		98707DFA24167A480045B811 /* FormatDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatDisplayTests.swift; sourceTree = "<group>"; };
+		9878D4CC243CAF0F00F79FD6 /* TypeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeUtils.swift; sourceTree = "<group>"; };
+		9878D4CE243CAF4700F79FD6 /* TypeUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeUtilsTests.swift; sourceTree = "<group>"; };
 		98790020222DA7E600880334 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		987C57A423A4EAF80060499B /* MapInfoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapInfoView.swift; sourceTree = "<group>"; };
 		987C57A523A4EAF80060499B /* MapInfoView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MapInfoView.xib; sourceTree = "<group>"; };
@@ -797,6 +801,7 @@
 				948509A222C09F9A0034FAF1 /* UIViewController+Management.swift */,
 				94FCBD25226C57CA00F93F94 /* UIWindow+Appearance.swift */,
 				94CCC8B723D0587F000CCE2A /* UserDefaults+Additions.swift */,
+				9878D4CC243CAF0F00F79FD6 /* TypeUtils.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -897,6 +902,7 @@
 				94CF087F19BDEAF2009FFF43 /* Supporting Files */,
 				98CE7322240EA4CE0088F7B4 /* NextRidesRequestTests.swift */,
 				98707DFA24167A480045B811 /* FormatDisplayTests.swift */,
+				9878D4CE243CAF4700F79FD6 /* TypeUtilsTests.swift */,
 			);
 			path = CriticalMassTests;
 			sourceTree = "<group>";
@@ -1404,6 +1410,7 @@
 				98C1327B227B8FE600291FCA /* IdentifiableAnnnotation.swift in Sources */,
 				9822A15E21F10FCA007F5994 /* LocationProvider.swift in Sources */,
 				94829429238AA39D00338E7F /* MKMapView+Register.swift in Sources */,
+				9878D4CD243CAF0F00F79FD6 /* TypeUtils.swift in Sources */,
 				9804176521FC71770077D419 /* MessagesTableViewController.swift in Sources */,
 				98970871220A4E180073BB02 /* CustomButton.swift in Sources */,
 				944D5F03240CE08000993899 /* CMAnnotationController.swift in Sources */,
@@ -1455,6 +1462,7 @@
 			files = (
 				9822A16621F11519007F5994 /* AppDataStoreTests.swift in Sources */,
 				3FDA7C13240B0EA3004EE8A6 /* MockNetworkObserver.swift in Sources */,
+				9878D4CF243CAF4700F79FD6 /* TypeUtilsTests.swift in Sources */,
 				98003D602287301000592D55 /* FollowURLObjectTests.swift in Sources */,
 				9810C384229831720011F718 /* RatingHelperTests.swift in Sources */,
 				949EBB1824102F4900E4F93B /* StringAdditionsTests.swift in Sources */,

--- a/CriticalMass/BikeAnnotationController.swift
+++ b/CriticalMass/BikeAnnotationController.swift
@@ -36,7 +36,7 @@ class BikeAnnotationController: AnnotationController {
         var unmatchedLocations = locations
         var unmatchedAnnotations: [MKAnnotation] = []
         // update existing annotations
-        mapView.annotations.compactMap { $0 as? BikeAnnotation }.forEach { annotation in
+        mapView.annotations.compactMap(castTo(BikeAnnotation.self)).forEach { annotation in
             if let location = unmatchedLocations[annotation.identifier] {
                 annotation.location = location
                 unmatchedLocations.removeValue(forKey: annotation.identifier)

--- a/CriticalMass/CMAnnotationController.swift
+++ b/CriticalMass/CMAnnotationController.swift
@@ -67,8 +67,7 @@ final class CMMarkerAnnotationController: AnnotationController {
 
     @objc private func checkRide() {
         guard let rideAnnotation = mapView.annotations.first(
-            where: { $0 is CriticalMassAnnotation }
-        ) as? CriticalMassAnnotation else {
+            where: canBeCastedTo(CriticalMassAnnotation.self)) as? CriticalMassAnnotation else {
             Logger.log(.debug, log: .default, "Expected annotation")
             return
         }
@@ -141,8 +140,7 @@ final class CMAnnotationController: AnnotationController {
 
     @objc private func checkRide() {
         guard let rideAnnotation = mapView.annotations.first(
-            where: { $0 is CriticalMassAnnotation }
-        ) as? CriticalMassAnnotation else {
+            where: canBeCastedTo(CriticalMassAnnotation.self)) as? CriticalMassAnnotation else {
             Logger.log(.debug, log: .default, "Expected annotation")
             return
         }

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -92,7 +92,7 @@ class MapViewController: UIViewController {
 
     private func registerAnnotationViews() {
         annotationControllers
-            .map { $0.annotationViewType }
+            .map(\.annotationViewType)
             .forEach(mapView.register)
     }
 
@@ -185,7 +185,7 @@ class MapViewController: UIViewController {
             switch result {
             case let .success(ride):
                 onMain { [unowned self] in
-                    self.annotationControllers.first(where: { $0.annotationType == CriticalMassAnnotation.self })
+                    self.annotationControllers.first(where: canBeCastedTo(CriticalMassAnnotation.self))
                         .flatMap {
                             if #available(iOS 11.0, *) {
                                 guard let controller = $0 as? CMMarkerAnnotationController else {

--- a/CriticalMass/SocialViewController.swift
+++ b/CriticalMass/SocialViewController.swift
@@ -26,7 +26,7 @@ class SocialViewController: UIViewController, UIToolbarDelegate {
     private var twitterController: UIViewController
 
     private lazy var segmentedControl: UISegmentedControl = {
-        let control = UISegmentedControl(items: SocialSegments.allCases.map { $0.title })
+        let control = UISegmentedControl(items: SocialSegments.allCases.map(\.title))
         control.selectedSegmentIndex = 0
         control.addTarget(self, action: #selector(socialSelectionDidChange(control:)),
                           for: .valueChanged)

--- a/CriticalMass/TypeUtils.swift
+++ b/CriticalMass/TypeUtils.swift
@@ -1,0 +1,12 @@
+//
+// Created for CriticalMaps in 2020
+
+import Foundation
+
+func castTo<to: Any>(_ to: to.Type) -> (_ from: Any) -> (to?) {
+    return { f in f as? to }
+}
+
+func canBeCastedTo<to: Any>(_ to: to.Type) -> (_ from: Any) -> (Bool) {
+    return { f in f is to }
+}

--- a/CriticalMassTests/TypeUtilsTests.swift
+++ b/CriticalMassTests/TypeUtilsTests.swift
@@ -1,0 +1,30 @@
+//
+// Created for CriticalMaps in 2020
+
+@testable import CriticalMaps
+import XCTest
+
+class TypeUtilsTests: XCTestCase {
+    func testCastToMap() {
+        let input: [Any] = [1, 2, "3", 4, "5"]
+        let expectedOutput = [1, 2, 4]
+        let output = input.compactMap(castTo(Int.self))
+        XCTAssertEqual(expectedOutput, output)
+    }
+
+    func testCastTo() {
+        XCTAssertEqual(castTo(Int.self)(1 as Any), 1)
+    }
+
+    func testCannotCastTo() {
+        XCTAssertNil(castTo(Int.self)("1"))
+    }
+
+    func testCanBeCastedTo() {
+        XCTAssertTrue(canBeCastedTo(Int.self)(1 as Any))
+    }
+
+    func testCannotBeCastedTo() {
+        XCTAssertFalse(canBeCastedTo(Int.self)("1" as Any))
+    }
+}


### PR DESCRIPTION
## 📲 What

I started to replace {.$0.property } with the new key path functions introduced in swift 5.2 \.property and then experimented with some more helpers to replace $0 syntax with a more easy readable API and introduced `castTo` and `canBeCastedTo`.

## 🤔 Why

The goal of this PR is to make the code more readable. On the other side, we keep introducing custom helpers so it might also have the opposite effect. What do you think?
