### PR TITLE
Disable SPM Cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Cache SPM
-      uses: actions/cache@v1
-      with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
+    # - name: Cache SPM
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: .build
+    #     key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-spm-
 
     - name: Cache Bundler
       uses: actions/cache@v1
@@ -90,13 +90,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Cache SPM
-      uses: actions/cache@v1
-      with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
+    # - name: Cache SPM
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: .build
+    #     key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-spm-
 
     - name: Cache Bundler
       uses: actions/cache@v1
@@ -122,13 +122,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Cache SPM
-      uses: actions/cache@v1
-      with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
+    # - name: Cache SPM
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: .build
+    #     key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-spm-
 
     - name: Cache Bundler
       uses: actions/cache@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,13 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Cache SPM
-      uses: actions/cache@v1
-      with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
+    # - name: Cache SPM
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: .build
+    #     key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+    #     restore-keys: |
+    #       ${{ runner.os }}-spm-
 
     - name: Cache Bundler
       uses: actions/cache@v1

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache SPM
-        uses: actions/cache@v1
-        with:
-          path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
+      # - name: Cache SPM
+      #   uses: actions/cache@v1
+      #   with:
+      #     path: .build
+      #     key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-spm-
 
       - name: Cache Bundler
         uses: actions/cache@v1


### PR DESCRIPTION
## 📲 What

Somethings wrong with the SPM cache. I couldn't find an option to reset caches on CI machines... how should errors with caches be handled??? 

For example in this [job](https://github.com/criticalmaps/criticalmaps-ios/runs/597469190):
```
Run swift build
[1/29] Compiling CriticalMapsKit APIRequest.swift
<unknown>:0: error: PCH was compiled with module cache path '/Users/runner/runners/2.168.0/work/criticalmaps-ios/criticalmaps-ios/.build/x86_64-apple-macosx/debug/ModuleCache/19B30ZHLDOJUE', 
but the path is currently '/Users/runner/runners/2.169.0/work/criticalmaps-ios/criticalmaps-ios/.build/x86_64-apple-macosx/debug/ModuleCache/19B30ZHLDOJUE'
<unknown>:0: error: missing required module 'SwiftShims'
```

This [SPM job](https://github.com/criticalmaps/criticalmaps-ios/pull/285/checks?check_run_id=597464974) is only green because there was an issue reading the cache: 
```
Cache SPM
[warning]No scopes with read permission were found on the request.
Run actions/cache@v1
[warning]No scopes with read permission were found on the request.
```

## 🤔 Why

Pipeline should be green, so caches are currently disabled.