### PR TITLE
Disabled events feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Changelog for Critical Maps iOS
 ### Added
 
 - Fullpage screenshots of the Map
-- Showing next ride event notification and annotation view on the map.
 
 ### Fixed
 

--- a/CriticalMass/Feature.swift
+++ b/CriticalMass/Feature.swift
@@ -11,12 +11,14 @@ import Foundation
 
 private var currentState: [Feature: Bool] = [
     .friends: false,
-    .errorHandler: false
+    .errorHandler: false,
+    .events: false
 ]
 
 enum Feature {
     case friends
     case errorHandler
+    case events
 
     var isActive: Bool {
         set { currentState[self] = newValue }

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -181,6 +181,9 @@ class MapViewController: UIViewController {
     }
 
     private func getNextRide(_ coordinate: CLLocationCoordinate2D) {
+        guard Feature.events.isActive else {
+            return
+        }
         nextRideManager.getNextRide(around: coordinate) { result in
             switch result {
             case let .success(ride):


### PR DESCRIPTION
## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

I reintroduced a feature flag for the Events feature and disabled it for now

## 🤔 Why

I could be misleading if we present user rides that don't happen. I think we should release the feature, once rides can happen again.
