### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "criticalmaps/ios"


### PR DESCRIPTION
## 📲 What

Resolves #304 

Add `dependabot.yml` to enable automatically updates for bundler (more [information](https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates)).

I _think_ with adding this yml file, everything should work already, but I'm not 100% sure. We should discuss the schedule because "daily" might be to much for this repository. 

I don't know if we can test this feature somehow before merging 🤔 

## 🤔 Why

Our GitHub Action to update the dependencies removes the license information (most of the time).

