### PR TITLE
Update Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    reviewers:
+      - "criticalmaps/ios"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,15 @@ updates:
   - package-ecosystem: "bundler" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      # Check for bundler updates on Saturdays
+      day: "saturday"
     reviewers:
       - "criticalmaps/ios"
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## 📲 What

- Update Dependabot Configuration to create PRs weekly on saturday. 
- Add monthly Dependabot Updates for Github Actions.

## 🤔 Why

Daily PRs would be too much. 