### PR TITLE
Add Indentation Configuration for Xcode Project

### DIFF
--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -846,7 +846,10 @@
 				94CF085E19BDEAF2009FFF43 /* Frameworks */,
 				94CF085D19BDEAF2009FFF43 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		94CF085D19BDEAF2009FFF43 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
## 📲 What

This setting prevents having unintentional different indentation styles in the project.

## 🤔 Why

This is especially useful when a developer (like me) defaults to indentation with tabs in Xcode [as accessibility feature](https://www.reddit.com/r/javascript/comments/c8drjo/nobody_talks_about_the_real_reason_to_use_tabs/). 
