### PR TITLE
[Refactor] facade userdefaults

### DIFF
--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -943,19 +943,23 @@
 		94CF087E19BDEAF2009FFF43 /* CriticalMassTests */ = {
 			isa = PBXGroup;
 			children = (
-				98CA8EDE2411482C000EFDCC /* CriticalMaps.xctestplan */,
 				9822A16521F11519007F5994 /* AppDataStoreTests.swift */,
 				9804178F21FCA2B40077D419 /* ChatManagerTests.swift */,
 				944D5F0A240CE0DA00993899 /* CMMarkerAnnotationControllerTests.swift */,
+				9F47462524C968370020B540 /* CodableExtensionTests.swift */,
 				944D5F09240CE0DA00993899 /* CoordinateObfuscatorTests.swift */,
 				94AF230823D6D64600267E87 /* DateAdditionsTests.swift */,
 				98003D5F2287301000592D55 /* FollowURLObjectTests.swift */,
+				98707DFA24167A480045B811 /* FormatDisplayTests.swift */,
 				98ED2FDC22919BDD007F8A92 /* FriendsVerificationControllerTests.swift */,
 				98CE731824085E4A0088F7B4 /* IdentifiableAnnotationTests.swift */,
 				98C13289227F05E700291FCA /* IDStoreTests.swift */,
 				98329A2222D3CADB00A157EE /* KeychainHelperTests.swift */,
+				21D1A39224A8C3AF00987AD0 /* MessagesDefaultDataSourceTests.swift */,
+				21BC979C24A8CE7600448240 /* MessagesDiffableDataSourceTests.swift */,
 				9843FAA2236CDC0D00457930 /* NetworkOperatorTests.swift */,
 				94F70B4523DA037A0086619E /* NextRideManagerTests.swift */,
+				98CE7322240EA4CE0088F7B4 /* NextRidesRequestTests.swift */,
 				9810C383229831720011F718 /* RatingHelperTests.swift */,
 				9822A16321F113DC007F5994 /* RequestManagerTests.swift */,
 				944D5F0B240CE0DA00993899 /* RideCheckerTests.swift */,
@@ -967,12 +971,8 @@
 				982DA8D521FFAC0D00E2A51B /* TwitterManagerTests.swift */,
 				988BF2F823F35C7100594C3F /* TwitterRequestTests.swift */,
 				981C92082288B47F00391FA9 /* XCTestCase+Helper.swift */,
+				98CA8EDE2411482C000EFDCC /* CriticalMaps.xctestplan */,
 				94CF087F19BDEAF2009FFF43 /* Supporting Files */,
-				98CE7322240EA4CE0088F7B4 /* NextRidesRequestTests.swift */,
-				98707DFA24167A480045B811 /* FormatDisplayTests.swift */,
-				21D1A39224A8C3AF00987AD0 /* MessagesDefaultDataSourceTests.swift */,
-				21BC979C24A8CE7600448240 /* MessagesDiffableDataSourceTests.swift */,
-				9F47462524C968370020B540 /* CodableExtensionTests.swift */,
 			);
 			path = CriticalMassTests;
 			sourceTree = "<group>";

--- a/CriticalMapsSnapshotTests/SettingsViewControllerSnapshotTests.swift
+++ b/CriticalMapsSnapshotTests/SettingsViewControllerSnapshotTests.swift
@@ -5,6 +5,10 @@
 import XCTest
 
 class SettingsViewControllerSnapshotTests: XCTestCase {
+    struct ObservationModePreferenceMock: ObservationModePreference {
+        var observationMode: Bool = false
+    }
+
     private let size = CGSize(width: 320, height: 1200)
 
     func testGeneralAppearance() {
@@ -12,7 +16,8 @@ class SettingsViewControllerSnapshotTests: XCTestCase {
         let viewController = SettingsViewController(
             themeController: MockThemeController.shared,
             dataStore: MockDataStore(),
-            idProvider: MockIDProvider()
+            idProvider: MockIDProvider(),
+            observationModePreferenceStore: ObservationModePreferenceStore(store: ObservationModePreferenceMock())
         )
         let navigationController = UINavigationController(rootViewController: viewController)
 

--- a/CriticalMass/ChatInputViewController.swift
+++ b/CriticalMass/ChatInputViewController.swift
@@ -23,9 +23,8 @@ final class ChatInputViewController: UIViewController, IBConstructable {
     }
 
     @IBOutlet private var sendButton: UIButton!
-
+    var themeController: ThemeController!
     weak var delegate: ChatInputDelegate?
-    private let themeController = ThemeController()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/CriticalMass/ChatViewController.swift
+++ b/CriticalMass/ChatViewController.swift
@@ -19,7 +19,7 @@ class ChatViewController: UIViewController {
 
     private let messagesTableViewController = MessagesTableViewController<ChatMessageTableViewCell>()
     private let chatManager: ChatManager
-    private let chatInputViewController = ChatInputViewController.fromNib()
+    private var chatInputViewController: ChatInputViewController!
     private lazy var chatInputBottomConstraint = {
         NSLayoutConstraint(item: chatInputViewController.view!, attribute: .bottom, relatedBy: .equal, toItem: view, attribute: .bottom, multiplier: 1, constant: 0)
     }()
@@ -31,10 +31,12 @@ class ChatViewController: UIViewController {
     // ContentState
     weak var chatMessageActivityDelegate: ChatMessageActivityDelegate?
 
-    init(chatManager: ChatManager) {
+    init(chatManager: ChatManager, themeController: ThemeController) {
         self.chatManager = chatManager
         super.init(nibName: nil, bundle: nil)
+        chatInputViewController = ChatInputViewController.fromNib()
         chatInputViewController.delegate = self
+        chatInputViewController.themeController = themeController
     }
 
     required init?(coder _: NSCoder) {

--- a/CriticalMass/LocationManager.swift
+++ b/CriticalMass/LocationManager.swift
@@ -47,16 +47,18 @@ class LocationManager: NSObject, CLLocationManagerDelegate, LocationProvider {
             }
         }
         get {
-            guard type(of: self).accessPermission == .authorized, !ObservationModePreferenceStore().isEnabled else {
+            guard type(of: self).accessPermission == .authorized, !observationModePreferenceStore.isEnabled else {
                 return nil
             }
             return _currentLocation
         }
     }
 
+    private var observationModePreferenceStore: ObservationModePreferenceStore
     private let locationManager = CLLocationManager()
 
-    override init() {
+    init(observationModePreferenceStore: ObservationModePreferenceStore) {
+        self.observationModePreferenceStore = observationModePreferenceStore
         super.init()
         configureLocationManager()
     }

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -15,6 +15,28 @@ class MapViewController: UIViewController {
     private let nextRideManager: NextRideManager
 
     private let mapInfoViewController = MapInfoViewController.fromNib()
+    private lazy var annotationControllers: [AnnotationController] = {
+        [BikeAnnotationController(mapView: self.mapView), CMMarkerAnnotationController(mapView: self.mapView)]
+    }()
+
+    private let nightThemeOverlay = DarkModeMapOverlay()
+    public lazy var followMeButton: UserTrackingButton = {
+        UserTrackingButton(mapView: mapView)
+    }()
+
+    public var bottomContentOffset: CGFloat = 0 {
+        didSet {
+            mapView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: bottomContentOffset, right: 0)
+        }
+    }
+
+    private var mapView = MKMapView(frame: .zero)
+
+    private let gpsDisabledOverlayView: BlurryFullscreenOverlayView = {
+        let view = BlurryFullscreenOverlayView.fromNib()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
 
     init(
         themeController: ThemeController,
@@ -31,32 +53,6 @@ class MapViewController: UIViewController {
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    // MARK: Properties
-
-    private lazy var annotationControllers: [AnnotationController] = {
-        [BikeAnnotationController(mapView: self.mapView), CMMarkerAnnotationController(mapView: self.mapView)]
-    }()
-
-    private let nightThemeOverlay = DarkModeMapOverlay()
-    public lazy var followMeButton: UserTrackingButton = {
-        let button = UserTrackingButton(mapView: mapView)
-        return button
-    }()
-
-    public var bottomContentOffset: CGFloat = 0 {
-        didSet {
-            mapView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: bottomContentOffset, right: 0)
-        }
-    }
-
-    private var mapView = MKMapView(frame: .zero)
-
-    private let gpsDisabledOverlayView: BlurryFullscreenOverlayView = {
-        let view = BlurryFullscreenOverlayView.fromNib()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/CriticalMass/NextRideManager.swift
+++ b/CriticalMass/NextRideManager.swift
@@ -11,18 +11,13 @@ enum EventError: Error {
 
 class NextRideManager {
     typealias ResultCallback = (Result<Ride, Error>) -> Void
-    private enum Constants {
-        static let filterDistance: Double = {
-            Double(UserDefaults.standard.nextRideRadius * 1000)
-        }()
-    }
 
     public var nextRide: Ride?
 
     private let apiHandler: CMInApiHandling
     private let filterDistance: Double
 
-    init(apiHandler: CMInApiHandling, filterDistance: Double = Constants.filterDistance) {
+    init(apiHandler: CMInApiHandling, filterDistance: Double) {
         self.apiHandler = apiHandler
         self.filterDistance = filterDistance
     }
@@ -39,7 +34,7 @@ class NextRideManager {
 
     private func filterRidesInRange(_ rides: [Ride], _ userCoordinate: CLLocationCoordinate2D) -> [Ride] {
         rides.filter {
-            $0.coordinate.clLocation.distance(from: userCoordinate.clLocation) < filterDistance
+            $0.coordinate.clLocation.distance(from: userCoordinate.clLocation) < (filterDistance * 1000)
         }
     }
 

--- a/CriticalMass/Preferences.swift
+++ b/CriticalMass/Preferences.swift
@@ -7,17 +7,21 @@
 
 import Foundation
 
-class ObservationModePreferenceStore: Switchable {
-    private let defaults: UserDefaults
+protocol ObservationModePreference {
+    var observationMode: Bool { get set }
+}
 
-    init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
+class ObservationModePreferenceStore: Switchable {
+    private var store: ObservationModePreference
+
+    init(store: ObservationModePreference) {
+        self.store = store
     }
 
     var isEnabled: Bool {
-        get { defaults.observationMode }
+        get { store.observationMode }
         set {
-            defaults.observationMode = newValue
+            store.observationMode = newValue
             NotificationCenter.default.post(name: .observationModeChanged, object: newValue)
         }
     }

--- a/CriticalMass/SettingsSection.swift
+++ b/CriticalMass/SettingsSection.swift
@@ -66,8 +66,17 @@ enum Section: CaseIterable {
         switch self {
         case .preferences:
             var models = [
-                Model(title: L10n.themeLocalizedString, action: .switch(ThemeController.self), accessibilityIdentifier: "Theme"),
-                Model(title: L10n.obversationModeTitle, subtitle: L10n.obversationModeDetail, action: .switch(ObservationModePreferenceStore.self), accessibilityIdentifier: "Observation_Mode"),
+                Model(
+                    title: L10n.themeLocalizedString,
+                    action: .switch(ThemeController.self),
+                    accessibilityIdentifier: "Theme"
+                ),
+                Model(
+                    title: L10n.obversationModeTitle,
+                    subtitle: L10n.obversationModeDetail,
+                    action: .switch(ObservationModePreferenceStore.self),
+                    accessibilityIdentifier: L10n.obversationModeTitle
+                ),
                 Model(
                     title: "App Icon",
                     action: .navigate(toViewController: AppIconSelectViewController.self),
@@ -75,7 +84,12 @@ enum Section: CaseIterable {
                 )
             ]
             if Feature.friends.isActive {
-                let friendsModel = Model(title: L10n.settingsFriends, subtitle: nil, action: .navigate(toViewController: ManageFriendsViewController.self), accessibilityIdentifier: "Friends")
+                let friendsModel = Model(
+                    title: L10n.settingsFriends,
+                    subtitle: nil,
+                    action: .navigate(toViewController: ManageFriendsViewController.self),
+                    accessibilityIdentifier: L10n.settingsFriends
+                )
                 models.insert(friendsModel, at: 0)
             }
             return models

--- a/CriticalMass/SettingsViewController.swift
+++ b/CriticalMass/SettingsViewController.swift
@@ -11,11 +11,18 @@ class SettingsViewController: UITableViewController {
     private let themeController: ThemeController
     private let dataStore: DataStore
     private let idProvider: IDProvider
+    private let observationModePreferenceStore: ObservationModePreferenceStore
 
-    init(themeController: ThemeController, dataStore: DataStore, idProvider: IDProvider) {
+    init(
+        themeController: ThemeController,
+        dataStore: DataStore,
+        idProvider: IDProvider,
+        observationModePreferenceStore: ObservationModePreferenceStore
+    ) {
         self.themeController = themeController
         self.dataStore = dataStore
         self.idProvider = idProvider
+        self.observationModePreferenceStore = observationModePreferenceStore
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -158,7 +165,7 @@ extension SettingsViewController {
                 case let .switch(switchableType) = model.action
             {
                 if switchableType == ObservationModePreferenceStore.self {
-                    switchCell.configure(switchable: ObservationModePreferenceStore())
+                    switchCell.configure(switchable: observationModePreferenceStore)
                 } else if switchableType == ThemeController.self {
                     switchCell.configure(switchable: themeController)
                 } else {

--- a/CriticalMass/ThemeController.swift
+++ b/CriticalMass/ThemeController.swift
@@ -13,7 +13,7 @@ class ThemeController {
     private(set) var currentTheme: Theme!
     private let store: ThemeStorable
 
-    init(store: ThemeStorable = ThemeSelectionStore()) {
+    init(store: ThemeStorable) {
         self.store = store
         currentTheme = loadTheme()
     }

--- a/CriticalMass/ThemeStore.swift
+++ b/CriticalMass/ThemeStore.swift
@@ -8,29 +8,33 @@
 
 import Foundation
 
+protocol ThemeStore {
+    var theme: String? { get set }
+}
+
 protocol ThemeStorable {
     func save(_ themeSelection: Theme)
     func load() -> Theme?
 }
 
 class ThemeSelectionStore: ThemeStorable {
-    private let defaults: UserDefaults
+    private var store: ThemeStore
 
-    init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
+    init(store: ThemeStore) {
+        self.store = store
     }
 
     /// Save Theme to UserDefaults
     ///
     /// - Parameter themeSelection: The Theme that will be saved.
     func save(_ themeSelection: Theme) {
-        defaults.theme = themeSelection.rawValue
+        store.theme = themeSelection.rawValue
     }
 
     /// Fetches saved theme from the UserDefaults
     ///
     /// - Returns: Saved theme from a previous session or nil if this is the first start.
     func load() -> Theme? {
-        Theme(defaults.theme)
+        Theme(store.theme)
     }
 }

--- a/CriticalMass/UserDefaults+Additions.swift
+++ b/CriticalMass/UserDefaults+Additions.swift
@@ -5,21 +5,6 @@ import Foundation
 import UIKit
 
 extension UserDefaults {
-    public static func makeClearedInstance(
-        for functionName: StaticString = #function,
-        inFile fileName: StaticString = #file
-    ) -> UserDefaults {
-        let className = "\(fileName)".split(separator: ".")[0]
-        let testName = "\(functionName)".split(separator: "(")[0]
-        let suiteName = "de.pokuslabs.criticalmassberlin.test.\(className).\(testName)"
-
-        let defaults = self.init(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
-        return defaults
-    }
-}
-
-extension UserDefaults {
     private enum Keys {
         static let observationModeKey = "observationMode"
         static let lastMessageReadTimeIntervalKey = "lastMessageReadTimeInterval"
@@ -42,27 +27,16 @@ extension UserDefaults {
             return radius
         }
     }
+}
 
-    public var username: String? {
-        set { set(newValue, forKey: Keys.userNameKey) }
-        get { string(forKey: Keys.userNameKey) }
-    }
-
-    public var observationMode: Bool {
-        set { set(newValue, forKey: Keys.observationModeKey) }
-        get { bool(forKey: Keys.observationModeKey) }
-    }
-
-    public var lastMessageReadTimeInterval: Double {
-        set { set(newValue, forKey: Keys.lastMessageReadTimeIntervalKey) }
-        get { double(forKey: Keys.lastMessageReadTimeIntervalKey) }
-    }
-
+extension UserDefaults: ThemeStore {
     public var theme: String? {
         set { set(newValue, forKey: Keys.themeKey) }
         get { string(forKey: Keys.themeKey) }
     }
+}
 
+extension UserDefaults: RatingStorage {
     public var lastDayUsed: Date? {
         set { set(newValue, forKey: Keys.lastDayUsedKey) }
         get { object(forKey: Keys.lastDayUsedKey) as? Date }
@@ -81,5 +55,26 @@ extension UserDefaults {
     public var lastRatedVersion: String? {
         set { set(newValue, forKey: Keys.lastRatedVersionKey) }
         get { string(forKey: Keys.lastRatedVersionKey) }
+    }
+}
+
+extension UserDefaults: ChatMessageStore {
+    public var lastMessageReadTimeInterval: Double {
+        set { set(newValue, forKey: Keys.lastMessageReadTimeIntervalKey) }
+        get { double(forKey: Keys.lastMessageReadTimeIntervalKey) }
+    }
+}
+
+extension UserDefaults: FriendsStorage {
+    public var username: String? {
+        set { set(newValue, forKey: Keys.userNameKey) }
+        get { string(forKey: Keys.userNameKey) }
+    }
+}
+
+extension UserDefaults: ObservationModePreference {
+    public var observationMode: Bool {
+        set { set(newValue, forKey: Keys.observationModeKey) }
+        get { bool(forKey: Keys.observationModeKey) }
     }
 }

--- a/CriticalMassTests/AppDataStoreTests.swift
+++ b/CriticalMassTests/AppDataStoreTests.swift
@@ -11,17 +11,17 @@ import XCTest
 
 class AppDataStoreTests: XCTestCase {
     var sut: AppDataStore!
-    var userdefaults: UserDefaults!
+    var store: FriendsStorage!
 
     override func setUp() {
         super.setUp()
 
-        userdefaults = .makeClearedInstance()
+        store = FriendsStorageMock()
 
         var feature = Feature.friends
         feature.isActive = true
 
-        sut = AppDataStore(userDefaults: userdefaults)
+        sut = AppDataStore(friendsStorage: store)
         for friend in sut.friends {
             sut.remove(friend: friend)
         }
@@ -33,7 +33,7 @@ class AppDataStoreTests: XCTestCase {
     }
 
     func testNotificationAfterStoringLocations() {
-        let sut = AppDataStore()
+        let sut = AppDataStore(friendsStorage: store)
         let expectedObject = ApiResponse(locations: ["a": Location(longitude: 100, latitude: 100, timestamp: 100, name: "hello", color: "world")], chatMessages: [:])
         let exp = expectation(forNotification: .positionOthersChanged, object: nil) { (notification) -> Bool in
             notification.object as AnyObject as! ApiResponse == expectedObject
@@ -44,7 +44,7 @@ class AppDataStoreTests: XCTestCase {
     }
 
     func testNotificationAfterStoringChatMessage() {
-        let sut = AppDataStore()
+        let sut = AppDataStore(friendsStorage: store)
         let expectedObject = ApiResponse(locations: [:], chatMessages: ["b": ChatMessage(message: "Hello", timestamp: 1000)])
         let exp = expectation(forNotification: .positionOthersChanged, object: nil) { (notification) -> Bool in
             notification.object as AnyObject as! ApiResponse == expectedObject
@@ -55,7 +55,7 @@ class AppDataStoreTests: XCTestCase {
     }
 
     func testNoNoDoublicatedNotificationAfterStoringOldLocations() {
-        let sut = AppDataStore()
+        let sut = AppDataStore(friendsStorage: store)
         let expectedObject = ApiResponse(locations: ["a": Location(longitude: 100, latitude: 100, timestamp: 100, name: "hello", color: "world")], chatMessages: [:])
         var notificationCount = 0
         let exp = expectation(forNotification: .positionOthersChanged, object: nil) { (notification) -> Bool in
@@ -71,7 +71,7 @@ class AppDataStoreTests: XCTestCase {
     }
 
     func testNoNoDoublicatedNotificationAfterStoringOldMessages() {
-        let sut = AppDataStore()
+        let sut = AppDataStore(friendsStorage: store)
         let expectedObject = ApiResponse(locations: [:], chatMessages: ["b": ChatMessage(message: "Hello", timestamp: 1000)])
         var notificationCount = 0
         let exp = expectation(forNotification: .positionOthersChanged, object: nil) { (notification) -> Bool in
@@ -87,7 +87,7 @@ class AppDataStoreTests: XCTestCase {
     }
 
     func testUpdateFriendLocation() {
-        let sut = AppDataStore()
+//        let sut = AppDataStore(friendsStorage: userdefaults)
 
         XCTAssertEqual(sut.friends.count, 0)
 
@@ -102,14 +102,14 @@ class AppDataStoreTests: XCTestCase {
         let location = Location(longitude: 100, latitude: 100, timestamp: 100, name: "hello", color: "world")
         let response = [token: location]
 
-        sut.updateFriedLocations(locations: response)
+        sut.updateFriendsLocations(locations: response)
 
         XCTAssertTrue(sut.friends[0].isOnline)
         XCTAssertEqual(sut.friends[0].location, location)
     }
 
     func testAddAndLoadFriends() {
-        let sut = AppDataStore()
+        let sut = AppDataStore(friendsStorage: store)
 
         XCTAssertEqual(sut.friends.count, 0)
 
@@ -119,7 +119,7 @@ class AppDataStoreTests: XCTestCase {
         XCTAssertEqual(sut.friends.count, 1)
         XCTAssertEqual(sut.friends[0], friend)
 
-        let newStore = AppDataStore()
+        let newStore = AppDataStore(friendsStorage: store)
         XCTAssertEqual(newStore.friends.count, 1)
         XCTAssertEqual(newStore.friends[0], friend)
 
@@ -128,7 +128,7 @@ class AppDataStoreTests: XCTestCase {
     }
 
     func testAddAndDeleteFriends() {
-        let sut = AppDataStore()
+        let sut = AppDataStore(friendsStorage: store)
 
         XCTAssertEqual(sut.friends.count, 0)
 
@@ -144,7 +144,7 @@ class AppDataStoreTests: XCTestCase {
         XCTAssertEqual(sut.friends.count, 1)
         XCTAssertEqual(sut.friends[0], friend)
 
-        let newStore = AppDataStore()
+        let newStore = AppDataStore(friendsStorage: store)
         XCTAssertEqual(newStore.friends.count, 1)
         XCTAssertEqual(newStore.friends[0], friend)
 

--- a/CriticalMassTests/FriendsVerificationControllerTests.swift
+++ b/CriticalMassTests/FriendsVerificationControllerTests.swift
@@ -10,30 +10,35 @@ import CriticalMaps
 import XCTest
 
 class FriendsVerificationControllerTests: XCTestCase {
+    var sut: FriendsVerificationController!
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
     func testVerifyFriend() throws {
         let token = UUID().uuidString
-
         let friend = Friend(name: "Jan Ullrich", token: token)
-        let store = AppDataStore()
+        let store = AppDataStore(friendsStorage: FriendsStorageMock())
         store.add(friend: friend)
 
         let realToken = IDStore.hash(id: token)
 
-        let friendsVerificationController = FriendsVerificationController(dataStore: store)
-        let result = friendsVerificationController.isFriend(id: realToken)
+        sut = FriendsVerificationController(dataStore: store)
+        let result = sut.isFriend(id: realToken)
         XCTAssertTrue(result)
     }
 
     func testVerifyNoFriend() throws {
         let token = UUID().uuidString
         let friend = Friend(name: "Jan Ullrich", token: token)
-        let store = AppDataStore()
+        let store = AppDataStore(friendsStorage: FriendsStorageMock())
         store.add(friend: friend)
+        sut = FriendsVerificationController(dataStore: store)
 
         let id = UUID().uuidString
-
-        let friendsVerificationController = FriendsVerificationController(dataStore: store)
-        let result = friendsVerificationController.isFriend(id: id)
+        let result = sut.isFriend(id: id)
         XCTAssertFalse(result)
     }
 }

--- a/CriticalMassTests/NextRideManagerTests.swift
+++ b/CriticalMassTests/NextRideManagerTests.swift
@@ -13,7 +13,7 @@ class NextRideManagerTests: XCTestCase {
         super.setUp()
         networkLayer = MockNetworkLayer()
         let apiHandler = CMInApiHandler(networkLayer: networkLayer)
-        nextRideManager = NextRideManager(apiHandler: apiHandler)
+        nextRideManager = NextRideManager(apiHandler: apiHandler, filterDistance: 10)
     }
 
     override func tearDown() {

--- a/CriticalMassTests/RatingHelperTests.swift
+++ b/CriticalMassTests/RatingHelperTests.swift
@@ -106,7 +106,7 @@ class RatingHelperTests: XCTestCase {
     }
 }
 
-struct RatingStorageMock: RatingStorage {
+private struct RatingStorageMock: RatingStorage {
     var lastDayUsed: Date?
     var daysCounter: Int = 0
     var usesCounter: Int = 0

--- a/CriticalMassTests/ThemeStoreTests.swift
+++ b/CriticalMassTests/ThemeStoreTests.swift
@@ -9,14 +9,18 @@
 @testable import CriticalMaps
 import XCTest
 
+struct ThemeStoreMock: ThemeStore {
+    var theme: String?
+}
+
 class ThemeSelectionStoreTests: XCTestCase {
     private var sut: ThemeSelectionStore?
-    private var userdefaults: UserDefaults!
+    private var store: ThemeStore!
 
     override func setUp() {
         super.setUp()
-        userdefaults = .makeClearedInstance()
-        sut = ThemeSelectionStore(defaults: userdefaults)
+        store = ThemeStoreMock()
+        sut = ThemeSelectionStore(store: store)
     }
 
     override func tearDown() {

--- a/CriticalMassTests/ThemeStoreTests.swift
+++ b/CriticalMassTests/ThemeStoreTests.swift
@@ -9,10 +9,6 @@
 @testable import CriticalMaps
 import XCTest
 
-struct ThemeStoreMock: ThemeStore {
-    var theme: String?
-}
-
 class ThemeSelectionStoreTests: XCTestCase {
     private var sut: ThemeSelectionStore?
     private var store: ThemeStore!
@@ -44,4 +40,8 @@ class ThemeSelectionStoreTests: XCTestCase {
         // then
         XCTAssertEqual(loadedTheme, .dark)
     }
+}
+
+private struct ThemeStoreMock: ThemeStore {
+    var theme: String?
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📲 What

This PR is intending to cut the Stores into smaller pieces and instead of injecting or directly referencing `UserDefaults` using Protocols to define what properties are accessible from an injected resource.

The `UserDefaults` then conform to these Protocols.

## 🤔 Why

* Clearer dependencies
* Removes UserDefaults from Tests