### PR TITLE
Fix GithubAction First Contribution from Forks

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [pull_request, issues]
+on: [pull_request_target, issues]
 
 jobs:
   greeting:


### PR DESCRIPTION
## 📲 What

This will (hopefully) fix the failing greeting pipeline from [here](https://github.com/criticalmaps/criticalmaps-ios/pull/330). The reason why it failed is probably that actions from forks can't access the github actions which are configured in this repository. That's why we use this workaround on the main workflow:
```
on:
  push:
    branches:
    - master
  pull_request:
    branches:
    - master
```

instead of just using `on: [push]`. 

For our greetings problem it is a recommended solution to use `pull_request_target` instead of `pull_request`. 

See the discussions here: 
- https://github.com/actions/first-interaction/issues/10
- https://github.community/t/github-actions-are-severely-limited-on-prs/18179/18

## 🤔 Why

The greeting for first contributors fails when they add a PR from their fork. 
