### PR TITLE
fix MavView `bottomContentOffset` (for legal info)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog for Critical Maps iOS
 - Fix Dark Mode Color Behaviour in Action Indicator (in Rules, Settings) and Separator (in Settings)
 - Fix missing information for VoiceOver user for the navigationbar buttons
 - Fix VoiceControl labels on each view
+- Fix `bottomContentOffset` for NavigationOverlay (did hide the Legal button)
 
 ### Changed
 

--- a/CriticalMass/NavigationOverlayViewController.swift
+++ b/CriticalMass/NavigationOverlayViewController.swift
@@ -143,7 +143,7 @@ class NavigationOverlayViewController: UIViewController {
         let width: CGFloat = min(CGFloat(85 * items.count), maxWidth)
         view.frame.size = CGSize(width: width, height: 56)
         let superView = view.superview!
-        view.center = CGPoint(x: superView.center.x, y: superView.frame.maxY - view.frame.size.height)
+        view.center = CGPoint(x: superView.center.x, y: superView.frame.maxY - view.frame.size.height - superView.layoutMargins.bottom)
 
         let buttonSize = CGSize(width: view.bounds.width / CGFloat(items.count), height: view.bounds.height)
         for (index, view) in (itemViews + separatorViews).enumerated() {

--- a/CriticalMass/NavigationOverlayViewController.swift
+++ b/CriticalMass/NavigationOverlayViewController.swift
@@ -157,6 +157,6 @@ class NavigationOverlayViewController: UIViewController {
         }
         visualEffectView.frame = view.bounds
 
-        (parent as? MapViewController)?.bottomContentOffset = view.frame.height
+        (parent as? MapViewController)?.bottomContentOffset = view.frame.height * 1.5
     }
 }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

Fix the bottom (y-) positioning of the NavigationOverlay 'tab/nav bar'.

Alternative (suggested by issue-creator):
Which I don't think will work with the AppStore guidelines...
> Maybe putting it on the info section on settings would be a good option.

## 🤔 Why

The **center** of the NavOverlay was set to the height of the 'tab/nav-Bar', causing a margin half the overlays height. Therefore the highest point of the overly is exactly 1.5 * the overlays height from the bottom of the screen. This was ignored when setting the `bottomContentOffset`, blocking the "Legal" button and potentially causing further problems in future updates.
Furthermore, `bottomContentOffset` takes into account `layoutMargins.bottom`. Therefore the "Legal" button was only blocked on iPhone != X. Moving the NavOverlay a bit further up on those devices, improves usability.
> **Avoid explicitly placing interactive controls at the very bottom of the screen and in corners.** People use swipe gestures at the bottom edge of the display to access features like the Home screen and app switcher, and these gestures may cancel custom gestures you implement in this area. The far corners of the screen can be difficult areas for people to reach comfortably.
-Apple

## 👀 See

#329

- [x] Added snapshot tests (using iPhone 8 Simulator)

| Before 🐛 | After 🦋 |
| --- | --- |
| ![Simulator Screen Shot - iPhone 8 - 2020-10-08 at 20 46 19](https://user-images.githubusercontent.com/18512366/95553536-0e8f6d80-0a0f-11eb-8e11-662eac7ddf0c.png) | ![Simulator Screen Shot - iPhone 8 - 2020-10-08 at 20 44 52](https://user-images.githubusercontent.com/18512366/95553547-14854e80-0a0f-11eb-9c7b-b9e8023575e0.png) |
## ♿️ Accessibility 

- [ ] Tap targets use minimum of 44x44 pts dimensions
- [x] Works with VoiceOver
- [ ] Supports Dynamic Type 
