### PR TITLE
[FIX] MapInfoView topAnchor

### DIFF
--- a/CriticalMass/MapInfoViewController.swift
+++ b/CriticalMass/MapInfoViewController.swift
@@ -20,7 +20,7 @@ class MapInfoViewController: UIViewController, IBConstructable {
     private var infoView = MapInfoView.fromNib()
     private var visibleBottomConstraint: NSLayoutConstraint!
     private var infoViewContainerTopConstraint: NSLayoutConstraint {
-        infoViewContainer.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+        infoViewContainer.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 15)
     }
 
     public var closeButtonHandler: MapInfoView.TapHandler? {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📲 What

Add constant `15` to topAnchor of the map info view

## 🤔 Why

After adding #340 the map info view needs a little bit more headroom

## 👀 See

| Before 🐛 | After 🦋 |
| --- | --- |
| <img width="579" alt="Screenshot 2020-10-16 at 17 48 39" src="https://user-images.githubusercontent.com/14075359/96280434-40d53800-0fd8-11eb-87ba-6dee7a93aa28.png"> | <img width="697" alt="Screenshot 2020-10-16 at 17 48 57" src="https://user-images.githubusercontent.com/14075359/96280418-3b77ed80-0fd8-11eb-8371-b1e3dd04c367.png"> |