### PR TITLE
display background location indicator

### DIFF
--- a/CriticalMass/LocationManager.swift
+++ b/CriticalMass/LocationManager.swift
@@ -69,6 +69,7 @@ class LocationManager: NSObject, CLLocationManagerDelegate, LocationProvider {
         locationManager.activityType = .otherNavigation
         locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
         locationManager.delegate = self
+        locationManager.showsBackgroundLocationIndicator = true
         locationManager.startUpdatingLocation()
     }
 


### PR DESCRIPTION
## 📲 What

Set `showsBackgroundLocationIndicator` to true

## 🤔 Why

To be more transparent to users
https://developer.apple.com/documentation/corelocation/cllocationmanager/2923541-showsbackgroundlocationindicator