### PR TITLE
Adapt BikeAnnotationSize to equal the Sizes in Maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog for Critical Maps iOS
 
 # [Unreleased]
 
+### Fixed
+
+- Adapt BikeAnnotation Size to equal the Sizes in Maps
+
 # [3.9.1] - 2020-11-20
 
 ### Fixed 

--- a/CriticalMass/BikeAnnotationView.swift
+++ b/CriticalMass/BikeAnnotationView.swift
@@ -9,10 +9,10 @@ import MapKit
 
 class BikeAnnoationView: MKAnnotationView {
     private enum Constants {
-        static let smallSize = CGRect(x: 0, y: 0, width: 3, height: 3)
         static let defaultSize = CGRect(x: 0, y: 0, width: 7, height: 7)
-        static let large = CGRect(x: 0, y: 0, width: 14, height: 14)
-        static let extraLarge = CGRect(x: 0, y: 0, width: 28, height: 28)
+        static let large = CGRect(x: 0, y: 0, width: 10, height: 10)
+        static let extraLarge = CGRect(x: 0, y: 0, width: 14, height: 14)
+        static let extraExtraLarge = CGRect(x: 0, y: 0, width: 20, height: 20)
     }
 
     @objc
@@ -45,12 +45,14 @@ class BikeAnnoationView: MKAnnotationView {
 
     private func defineFrame() -> CGRect {
         switch traitCollection.preferredContentSizeCategory {
-        case .extraSmall, .small:
-            return Constants.smallSize
-        case .extraLarge, .accessibilityLarge, .accessibilityExtraLarge:
+        case .extraSmall, .small, .medium, .large:
+            return Constants.defaultSize
+        case .extraLarge:
             return Constants.large
-        case .extraExtraExtraLarge, .extraExtraExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge:
+        case .extraExtraLarge:
             return Constants.extraLarge
+        case .extraExtraExtraLarge, .accessibilityMedium, .accessibilityLarge, .accessibilityExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge:
+            return Constants.extraExtraLarge
         default:
             return Constants.defaultSize
         }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

Adapt the Bike Annotation Size to be equal the sizes in Maps. All Dynamic Type Sizes are now supported and you can test this in Xcode with the Environment Overrides Menu by activating Dynamic Type.

## 🤔 Why

Currently, there are some jumps in the size when the dynamic type gets higher. 

## 👀 See

Sadly Github doesn't support videos in PR descriptions, so here are some example Screenshots.

| Before L 🐛 | After L 🦋 |
| --- | --- |
| <img width="754" alt="Screen Shot 2020-12-06 at 15 25 34" src="https://user-images.githubusercontent.com/26111180/101282781-4cbec880-37d7-11eb-9820-cbbf5fd021b1.png"> | <img width="766" alt="Screen Shot 2020-12-06 at 15 24 41" src="https://user-images.githubusercontent.com/26111180/101282766-331d8100-37d7-11eb-9057-53fe9d7341f5.png"> |

| Before XL 🐛 | After XL 🦋 |
| --- | --- |
| <img width="760" alt="Screen Shot 2020-12-06 at 15 23 47" src="https://user-images.githubusercontent.com/26111180/101282731-0b2e1d80-37d7-11eb-92b7-9d38dbae1b0f.png"> | <img width="745" alt="Screen Shot 2020-12-06 at 15 24 22" src="https://user-images.githubusercontent.com/26111180/101282757-226d0b00-37d7-11eb-8a75-520948e66d99.png"> |

| Before XXL 🐛 | After XXL 🦋 |
| --- | --- |
| <img width="737" alt="Screen Shot 2020-12-06 at 15 27 29" src="https://user-images.githubusercontent.com/26111180/101282848-a626f780-37d7-11eb-98b6-c83e7180762c.png"> | <img width="740" alt="Screen Shot 2020-12-06 at 15 28 48" src="https://user-images.githubusercontent.com/26111180/101282873-c951a700-37d7-11eb-98bd-853e5c2905db.png"> |

| Before XXXL 🐛 | After XXXL 🦋 |
| --- | --- |
| <img width="736" alt="Screen Shot 2020-12-06 at 15 27 37" src="https://user-images.githubusercontent.com/26111180/101282849-a8895180-37d7-11eb-8597-d10033d384a9.png"> | <img width="735" alt="Screen Shot 2020-12-06 at 15 28 53" src="https://user-images.githubusercontent.com/26111180/101282874-cbb40100-37d7-11eb-8f81-b6881ded0ca0.png"> |

## ♿️ Accessibility 

- ~Tap targets use minimum of 44x44 pts dimensions~
- ~Works with VoiceOver~
- [x] Supports Dynamic Type 
