### PR TITLE
Fix Switching Appearance Settings and using `.system`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for Critical Maps iOS
 ### Fixed
 
 - Adapt BikeAnnotation Size to equal the Sizes in Maps
+- Fix Switching Appearance Settings and using `.system`
 
 # [3.9.1] - 2020-11-20
 

--- a/CriticalMass/MapViewController.swift
+++ b/CriticalMass/MapViewController.swift
@@ -182,16 +182,7 @@ class MapViewController: UIViewController {
         switch themeController.currentTheme {
         case .system:
             if #available(iOS 13.0, *) {
-                switch traitCollection.userInterfaceStyle {
-                case .dark:
-                    overrideUserInterfaceStyle = .dark
-                case .light:
-                    overrideUserInterfaceStyle = .light
-                case .unspecified:
-                    overrideUserInterfaceStyle = .unspecified
-                @unknown default:
-                    overrideUserInterfaceStyle = .light
-                }
+                overrideUserInterfaceStyle = .unspecified
             }
         case .light:
             if #available(iOS 13.0, *) {


### PR DESCRIPTION
## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

Setting `overrideUserInterfaceStyle = .unspecified` "causes the view controller to inherit the interface style from the system or a parent view controller" which is exactly what we want in this case.

Tested the feature on iOS 14.2 and iOS 12.1 in simulator.

## 🤔 Why

Fixes #379 and simplifies the logic a lot.
