### PR TITLE
Update Schedule of Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,14 @@
 
 version: 2
 updates:
-  - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "bundler"
+    directory: "/"
     schedule:
-      interval: "weekly"
-      # Check for bundler updates on Saturdays
-      day: "saturday"
+      interval: "monthly"
     reviewers:
       - "criticalmaps/ios"
 
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
     directory: "/"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
## 📲 What

This changes the schedule to monthly for all dependabot updates. This also removes some unhelpful comments.

## 🤔 Why

I think monthly updates are fine enough.
