### PR TITLE
[Events feature] add ride `enabled` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog for Critical Maps iOS
 
 ### Fixed
 
+- Fix a bug that showed cancelled events
 - Adapt BikeAnnotation Size to equal the Sizes in Maps
 - Fix Switching Appearance Settings and using `.system`
 

--- a/CriticalMass/NextRideManager.swift
+++ b/CriticalMass/NextRideManager.swift
@@ -73,6 +73,11 @@ final class NextRideManager {
                     handler(.failure(EventError.invalidDateError))
                     return
                 }
+                // check if ride is cancelled
+                guard ride.enabled else {
+                    handler(.failure(EventError.rideDisabled))
+                    return
+                }
                 handler(.success(ride))
                 return
             }
@@ -88,6 +93,12 @@ final class NextRideManager {
                 handler(.failure(EventError.invalidDateError))
                 return
             }
+            // check if ride is cancelled
+            guard ride.enabled else {
+                handler(.failure(EventError.rideDisabled))
+                return
+            }
+
             nextRide = ride
             handler(.success(ride))
         case let .failure(error):

--- a/CriticalMass/NextRideManager.swift
+++ b/CriticalMass/NextRideManager.swift
@@ -10,6 +10,7 @@ enum EventError: Error {
     case rideIsOutOfRangeError
     case noUpcomingRides
     case rideTypeIsFiltered
+    case rideDisabled
 }
 
 final class NextRideManager {

--- a/CriticalMass/NextRideManager.swift
+++ b/CriticalMass/NextRideManager.swift
@@ -78,6 +78,8 @@ final class NextRideManager {
                     handler(.failure(EventError.rideDisabled))
                     return
                 }
+
+                nextRide = ride
                 handler(.success(ride))
                 return
             }

--- a/CriticalMass/Ride.swift
+++ b/CriticalMass/Ride.swift
@@ -16,6 +16,7 @@ struct Ride: Hashable, Codable {
     let estimatedParticipants: Int?
     let estimatedDistance: Double?
     let estimatedDuration: Double?
+    let enabled: Bool
     let disabledReason: String?
     let disabledReasonMessage: String?
     let rideType: RideType?

--- a/CriticalMassTests/NextRideManagerTests.swift
+++ b/CriticalMassTests/NextRideManagerTests.swift
@@ -198,7 +198,8 @@ class NextRideManagerTests: XCTestCase {
             switch result {
             case .success:
                 XCTFail()
-            case .failure:
+            case .failure(let error):
+                XCTAssertEqual(error as! EventError, EventError.rideDisabled)
                 break
             }
             exp.fulfill()

--- a/CriticalMassTests/NextRideManagerTests.swift
+++ b/CriticalMassTests/NextRideManagerTests.swift
@@ -173,6 +173,40 @@ class NextRideManagerTests: XCTestCase {
         wait(for: [exp], timeout: 1)
     }
 
+    func testManagerShouldReturnErrorWhenRideIsCanceled() {
+        // given
+        networkLayer.mockResponse = [
+            Ride.TestData.cmBerlinDisabled
+        ]
+        let apiHandler = CMInApiHandler(networkLayer: networkLayer)
+        nextRideManager = NextRideManager(
+            apiHandler: apiHandler,
+            eventSettingsStore: RideEventSettingsStoreMock(
+                rideEventSettings: .init(
+                    isEnabled: true,
+                    typeSettings: .onlyCM,
+                    radiusSettings: .init(
+                        radius: 20,
+                        isEnabled: true
+                    )
+                )
+            )
+        )
+        // when
+        let exp = expectation(description: "Wait for response")
+        nextRideManager.getNextRide(around: CLLocationCoordinate2D.TestData.alexanderPlatz) { result in
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure:
+                break
+            }
+            exp.fulfill()
+        }
+        // then
+        wait(for: [exp], timeout: 1)
+    }
+
     func testManagerShouldReturnUnFilteredRideTypesWhenAllRidesDontHaveRideType() {
         // given
         networkLayer.mockResponse = [
@@ -223,6 +257,7 @@ extension Ride {
             estimatedParticipants: nil,
             estimatedDistance: nil,
             estimatedDuration: nil,
+            enabled: true,
             disabledReason: nil,
             disabledReasonMessage: nil,
             rideType: .criticalMass
@@ -239,6 +274,7 @@ extension Ride {
             estimatedParticipants: nil,
             estimatedDistance: nil,
             estimatedDuration: nil,
+            enabled: true,
             disabledReason: nil,
             disabledReasonMessage: nil,
             rideType: .criticalMass
@@ -255,6 +291,7 @@ extension Ride {
             estimatedParticipants: nil,
             estimatedDistance: nil,
             estimatedDuration: nil,
+            enabled: true,
             disabledReason: nil,
             disabledReasonMessage: nil,
             rideType: nil
@@ -271,6 +308,7 @@ extension Ride {
             estimatedParticipants: nil,
             estimatedDistance: nil,
             estimatedDuration: nil,
+            enabled: true,
             disabledReason: nil,
             disabledReasonMessage: nil,
             rideType: .kidicalMass
@@ -287,6 +325,7 @@ extension Ride {
             estimatedParticipants: nil,
             estimatedDistance: nil,
             estimatedDuration: nil,
+            enabled: true,
             disabledReason: nil,
             disabledReasonMessage: nil,
             rideType: nil
@@ -303,6 +342,24 @@ extension Ride {
             estimatedParticipants: nil,
             estimatedDistance: nil,
             estimatedDuration: nil,
+            enabled: true,
+            disabledReason: nil,
+            disabledReasonMessage: nil,
+            rideType: .criticalMass
+        )
+        static let cmBerlinDisabled = Ride(
+            id: 123,
+            slug: nil,
+            title: "Critical Mass Berlin",
+            description: nil,
+            dateTime: Date().addingTimeInterval(40000),
+            location: "Mariannenplatz",
+            latitude: 52.502148,
+            longitude: 13.424356,
+            estimatedParticipants: nil,
+            estimatedDistance: nil,
+            estimatedDuration: nil,
+            enabled: false,
             disabledReason: nil,
             disabledReasonMessage: nil,
             rideType: .criticalMass

--- a/CriticalMassTests/NextRidesRequestTests.swift
+++ b/CriticalMassTests/NextRidesRequestTests.swift
@@ -19,11 +19,11 @@ class NextRidesRequestTests: XCTestCase {
     }
 
     func testParseRespone() throws {
-        let responseData = "[{\"id\":8091,\"slug\":null,\"title\":\"Critical Mass Aachen 27.03.2020\",\"description\":null,\"dateTime\":1585328400,\"location\":\"Elisenbrunnen\",\"latitude\":50.774167,\"longitude\":6.086944,\"estimatedParticipants\":null,\"estimatedDistance\":null,\"estimatedDuration\":null}]".data(using: .utf8)!
+        let responseData = "[{\"id\":8091,\"slug\":null,\"title\":\"Critical Mass Aachen 27.03.2020\",\"description\":null,\"dateTime\":1585328400,\"location\":\"Elisenbrunnen\",\"latitude\":50.774167,\"longitude\":6.086944,\"estimatedParticipants\":null,\"estimatedDistance\":null,\"estimatedDuration\":null,\"enabled\": true}]".data(using: .utf8)!
 
         let request = NextRidesRequest(coordinate: CLLocationCoordinate2D(latitude: 42, longitude: 42), radius: 21)
 
-        let expectedRides = [Ride(id: 8091, slug: nil, title: "Critical Mass Aachen 27.03.2020", description: nil, dateTime: Date(timeIntervalSince1970: 1_585_328_400), location: "Elisenbrunnen", latitude: 50.774167, longitude: 6.086944, estimatedParticipants: nil, estimatedDistance: nil, estimatedDuration: nil, disabledReason: nil, disabledReasonMessage: nil, rideType: nil)]
+        let expectedRides = [Ride(id: 8091, slug: nil, title: "Critical Mass Aachen 27.03.2020", description: nil, dateTime: Date(timeIntervalSince1970: 1_585_328_400), location: "Elisenbrunnen", latitude: 50.774167, longitude: 6.086944, estimatedParticipants: nil, estimatedDistance: nil, estimatedDuration: nil, enabled: true, disabledReason: nil, disabledReasonMessage: nil, rideType: nil)]
         let rides = try request.parseResponse(data: responseData)
         XCTAssertEqual(expectedRides, rides)
     }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

* Add `enabled` parameter to ride object. https://github.com/criticalmass-one/criticalmass-in/blob/19251cdcea9db966a5e411c8a058d7a04aa92c7f/src/Entity/Ride.php#L315
* Make RideManager check if the "nextRide" is enabled and otherwise do not save it as the next ride
* save nextRide it is enabled but does not have an eventType set. Might happen since the API is not 💯

## 🤔 Why

* we do not want to show cancelled events.
* rides without eventType were showing on the map as an annotation and also the event banner is shown but tapping on it did not focus the next event since it was not set in the 'RideManager'. Coming back to the codebase after 3 months (even 3 months of not coding this feels weird... but 🤷‍♂️) 