### PR TITLE
[Fix Chat] - Add internal id to Chatmessage object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Changelog for Critical Maps iOS
 
+# [Unreleased]
+
+### Fixed
+
+- Identical chatmessages were crashing the chat  
+
 # [3.9.2] - 2021-05-04
 
 ### Fixed

--- a/CriticalMass/ChatMessage.swift
+++ b/CriticalMass/ChatMessage.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-public struct ChatMessage: Codable, Hashable {
+public struct ChatMessage: Codable {
+    let id = UUID()
     var message: String
     var timestamp: TimeInterval
 
@@ -15,5 +16,13 @@ public struct ChatMessage: Codable, Hashable {
         message
             .replacingOccurrences(of: "+", with: " ")
             .removingPercentEncoding
+    }
+
+    private enum CodingKeys: String, CodingKey { case message, timestamp }
+}
+
+extension ChatMessage: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }

--- a/CriticalMassTests/MessagesDefaultDataSourceTests.swift
+++ b/CriticalMassTests/MessagesDefaultDataSourceTests.swift
@@ -24,7 +24,7 @@ class MessagesDefaultDataSourceTests: XCTestCase {
         dataSource.messages.append(contentsOf: ChatMessage.testData)
 
         XCTAssertTrue(tableView.numberOfSections == 1)
-        XCTAssertTrue(tableView.numberOfRows(inSection: 0) == 3)
+        XCTAssertTrue(tableView.numberOfRows(inSection: 0) == 4)
     }
 
     func testClearingTableView() {
@@ -39,6 +39,7 @@ class MessagesDefaultDataSourceTests: XCTestCase {
 extension ChatMessage {
     static var testData: [ChatMessage] {
         [
+            ChatMessage(message: "message 1", timestamp: 111),
             ChatMessage(message: "message 1", timestamp: 111),
             ChatMessage(message: "message 2", timestamp: 121),
             ChatMessage(message: "message 3", timestamp: 311)

--- a/CriticalMassTests/MessagesDiffableDataSourceTests.swift
+++ b/CriticalMassTests/MessagesDiffableDataSourceTests.swift
@@ -25,7 +25,7 @@ class MessagesDiffableDataSourceTests: XCTestCase {
         dataSource.messages.append(contentsOf: ChatMessage.testData)
 
         XCTAssertTrue(tableView.numberOfSections == 1)
-        XCTAssertTrue(tableView.numberOfRows(inSection: 0) == 3)
+        XCTAssertTrue(tableView.numberOfRows(inSection: 0) == 4)
     }
 
     func testClearingTableView() {


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

Add an id to chat message object for diffing.

## 🤔 Why

The app crashed due to identical chat messages from the API. 

<details><summary>Xcode console log</summary>
<p>

```
2021-06-25 19:52:20.801165+0200 CriticalMaps[9495:418688] *** Assertion failure in -[_UIDiffableDataSourceUpdate initWithIdentifiers:sectionIdentifiers:action:desinationIdentifier:relativePosition:destinationIsSection:], _UIDiffableDataSourceHelpers.m:276
2021-06-25 19:52:20.833125+0200 CriticalMaps[9495:418688] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Fatal: supplied item identifiers are not unique.'
```

</p>
</details>

<details><summary>API Response</summary>
<p>

```json
"chatMessages": {
    "0f54d5029bc247adbb7ec91c5055d603": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641807
    },
    "b7bf5f2a7bad1e5fd7a7670a24b6a31a": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641810
    },
    "26e920ff436392ade0b6e31e7081bbd46d69ca34": {
      "message": "limmatplatz+ist+verstopft",
      "timestamp": 1624642031
    },
    "31f5da3f26d66a6efa374076b11b68f2": {
      "message": "  ich esse mini rosti und chum gleich",
      "timestamp": 1624643253
    },
    "1505ad4ee35916f5981ed15fa8fe927d": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641810
    },
    "a080ae4d63a03662caa715df15b6a71ab11bb1a8": {
      "message": "z%C3%BCri",
      "timestamp": 1624641983
    },
    "760ed05e6f4cabb049e3e9ab8fe5de1a1bc1b016": {
      "message": "kommst+du+33+nach+7+bs%3F+%F0%9F%98%84",
      "timestamp": 1624641944
    },
    "7059b4063d97731451054bb5fac6f452": {
      "message": "  ich esse mini rosti und chum gleich",
      "timestamp": 1624643255
    },
    "1192ea1231a35d98e0f9751f396c8c1a89840c24": {
      "message": "glaube+du+bist+jetzt+in+BS",
      "timestamp": 1624642537
    },
    "9eb7e2d85f89d5e6296c7929fd9d46cd": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641810
    },
    "0b7ab699f8e104a1b5e5f7f46e9ec200": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641808
    },
    "1877d41c172c3cc50967a1be7da63bff": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641810
    },
    "0301f61cf6bd33df79fbb4aff1ac67d6": {
      "message": "  ich esse mini rosti und chum gleich",
      "timestamp": 1624643255
    },
    "5bd27c6120bdaddf828d3392fdb7dcb9": {
      "message": "  ich esse mini rosti und chum gleich\n\n",
      "timestamp": 1624643258
    },
    "4d8e7472e056e795139d2bbec377331e": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641830
    },
    "6b66c04ddb89ae51235bd0b1bc3492eb": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641810
    },
    "a028cd992742444a304f1cf2bb96ae53": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641808
    },
    "52c5c10c4d2085bdde99e8444dc9b1b3": {
      "message": "komme voraussichtlich 33 nach 7 in BS an",
      "timestamp": 1624641807
    },
    "3c298431bde3ca8ff05f013b87b9bd4f": {
      "message": "  ich esse mini rosti und chum gleich\n\n",
      "timestamp": 1624643258
    },
    "034b1cb99c5c2a7da43ecb223991f42e6c4095de": {
      "message": "imma+diese+hochleistungs+Fahrraddemos+hier+in+Bochum...+wenn+die+ma+sone+Typen+wie+mich+mit+radeln+k%C3%BCssen+wir+aber+der+ganze+Pott+voll+mit+Radwegen%2C+ne.+ich+steh+noch+bei+die+Glocke+und+die+sind+schon+beim+Hannibal...",
      "timestamp": 1624643075
    }
  }
```

</p>
</details>