### PR TITLE
[🌏 Fix] Mirror L10n module strings files in app target to enable Localizations

### DIFF
--- a/App/iOS App/Info.plist
+++ b/App/iOS App/Info.plist
@@ -112,5 +112,13 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>de</string>
+		<string>en</string>
+        <string>es</string>
+        <string>fr</string>
+		<string>it</string>
+	</array>
 </dict>
 </plist>

--- a/App/iOS App/Info.plist
+++ b/App/iOS App/Info.plist
@@ -116,8 +116,8 @@
 	<array>
 		<string>de</string>
 		<string>en</string>
-        <string>es</string>
-        <string>fr</string>
+		<string>es</string>
+		<string>fr</string>
 		<string>it</string>
 	</array>
 </dict>

--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -330,6 +330,10 @@
 			knownRegions = (
 				en,
 				Base,
+				fr,
+				de,
+				it,
+				es,
 			);
 			mainGroup = 73CF5FB9263EAF5B001925A3;
 			productRefGroup = 73CF5FC3263EAF5B001925A3 /* Products */;


### PR DESCRIPTION
## 📲 What

Due to the new project structure the app needs to mirror the Packages `L10n` module language content to enable regional localizations.