### PR TITLE
Add all upcoming ride events list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This release is a rebuild of the app built with [`The Composable Architecture`](
 - Adopts new Styleguide
 - Contribute with translation view to Settings
 - Add increased contrast support
+- Show all ride events from `NextRide` overlay button contextMenu
 
 
 # [3.9.2] - 2021-05-04

--- a/CriticalMaps.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CriticalMaps.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "BottomSheet",
+        "repositoryURL": "https://github.com/adamfootdev/BottomSheet.git",
+        "state": {
+          "branch": null,
+          "revision": "0e6db002eeb5e3ba402e94dfe6a120f78b5a64df",
+          "version": "0.2.4"
+        }
+      },
+      {
         "package": "combine-schedulers",
         "repositoryURL": "https://github.com/pointfreeco/combine-schedulers",
         "state": {

--- a/CriticalMapsKit/Package.swift
+++ b/CriticalMapsKit/Package.swift
@@ -31,7 +31,8 @@ let package = Package(
       .exact("1.8.2")
     ),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.1.0"),
-    .package(url: "https://github.com/vtourraine/AcknowList.git", .upToNextMajor(from: "2.1.0"))
+    .package(url: "https://github.com/vtourraine/AcknowList.git", .upToNextMajor(from: "2.1.0")),
+    .package(url: "https://github.com/adamfootdev/BottomSheet.git", from: "0.1.3")
   ],
   targets: [
     .target(
@@ -60,7 +61,8 @@ let package = Package(
         "Styleguide",
         "UserDefaultsClient",
         "UIApplicationClient",
-        .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
+        .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+        .product(name: "BottomSheet", package: "BottomSheet")
       ]
     ),
     .target(
@@ -130,10 +132,7 @@ let package = Package(
         "Styleguide",
         "SwiftUIHelpers",
         .product(name: "ComposableCoreLocation", package: "composable-core-location"),
-        .product(
-          name: "ComposableArchitecture",
-          package: "swift-composable-architecture"
-        )
+        .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
       ]
     ),
     .target(

--- a/CriticalMapsKit/Sources/AppFeature/AppFeatureCore.swift
+++ b/CriticalMapsKit/Sources/AppFeature/AppFeatureCore.swift
@@ -64,9 +64,12 @@ public struct AppState: Equatable {
   
   public var chatMessageBadgeCount: UInt = 0
   public var hasConnectivity = true
+
+  public var presentEventsBottomSheet = false
 }
 
 // MARK: Actions
+
 public enum AppAction: Equatable {
   case appDelegate(AppDelegateAction)
   case onAppear
@@ -76,7 +79,8 @@ public enum AppAction: Equatable {
   case userSettingsLoaded(Result<UserSettings, NSError>)
   case observeConnection
   case observeConnectionResponse(NetworkPath)
-  
+
+  case setEventsBottomSheet(Bool)
   case setNavigation(tag: AppRoute.Tag?)
   case dismissSheetView
   
@@ -318,7 +322,14 @@ public let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
         default:
           return .none
         }
-                
+
+      case .focusNextRide:
+        if state.presentEventsBottomSheet {
+          return Effect(value: .setEventsBottomSheet(false))
+        } else {
+          return .none
+        }
+
       default:
         return .none
       }
@@ -363,7 +374,17 @@ public let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
         state.route = .none
       }
       return .none
-      
+
+    case let .setEventsBottomSheet(value):
+      if value {
+        state.mapFeatureState.rideEvents = state.nextRideState.rideEvents
+      } else {
+        state.mapFeatureState.rideEvents = []
+        state.mapFeatureState.eventCenter = nil
+      }
+      state.presentEventsBottomSheet = value
+      return .none
+
     case .dismissSheetView:
       state.route = .none
       return .none

--- a/CriticalMapsKit/Sources/AppFeature/AppView.swift
+++ b/CriticalMapsKit/Sources/AppFeature/AppView.swift
@@ -19,7 +19,7 @@ public struct AppView: View {
   
   public init(store: Store<AppState, AppAction>) {
     self.store = store
-    self.viewStore = ViewStore(store)
+    viewStore = ViewStore(store)
   }
   
   public var body: some View {

--- a/CriticalMapsKit/Sources/AppFeature/AppView.swift
+++ b/CriticalMapsKit/Sources/AppFeature/AppView.swift
@@ -109,14 +109,31 @@ public struct AppView: View {
               VStack(alignment: .leading, spacing: .grid(1)) {
                 Text(ride.title)
                   .multilineTextAlignment(.leading)
-                  .font(.titleTwo)
+                  .font(Font.body.weight(.semibold))
                   .foregroundColor(Color(.textPrimary))
-                Text(ride.rideDateAndTime)
-                  .multilineTextAlignment(.leading)
-                  .font(.bodyTwo)
-                  .foregroundColor(Color(.textSecondary))
+                  .padding(.bottom, .grid(1))
+                
+                VStack(alignment: .leading, spacing: 2) {
+                  Label(ride.dateTime.humanReadableDate, systemImage: "calendar")
+                    .multilineTextAlignment(.leading)
+                    .font(.bodyTwo)
+                    .foregroundColor(Color(.textSecondary))
+                  
+                  Label(ride.dateTime.humanReadableTime, systemImage: "clock")
+                    .multilineTextAlignment(.leading)
+                    .font(.bodyTwo)
+                    .foregroundColor(Color(.textSecondary))
+                  
+                  if let location = ride.location {
+                    Label(location, systemImage: "location.fill")
+                      .multilineTextAlignment(.leading)
+                      .font(.bodyTwo)
+                      .foregroundColor(Color(.textSecondary))
+                  }
+                }
               }
             }
+            .padding(.vertical, .grid(1))
             .accessibilityElement(children: .combine)
             .contentShape(Rectangle())
             .onTapGesture {

--- a/CriticalMapsKit/Sources/AppFeature/AppView.swift
+++ b/CriticalMapsKit/Sources/AppFeature/AppView.swift
@@ -1,6 +1,9 @@
+import BottomSheet
 import ComposableArchitecture
+import L10n
 import MapFeature
 import SharedEnvironment
+import SharedModels
 import Styleguide
 import SwiftUI
 
@@ -8,7 +11,10 @@ import SwiftUI
 public struct AppView: View {
   let store: Store<AppState, AppAction>
   @ObservedObject var viewStore: ViewStore<AppState, AppAction>
-  
+  @Environment(\.accessibilityReduceTransparency) var reduceTransparency
+
+  @State var presentBottomSheet = false
+
   let minHeight: CGFloat = 56
   
   public init(store: Store<AppState, AppAction>) {
@@ -17,7 +23,7 @@ public struct AppView: View {
   }
   
   public var body: some View {
-    ZStack {
+    ZStack(alignment: .topLeading) {
       MapFeatureView(
         store: store.scope(
           state: \.mapFeatureState,
@@ -36,13 +42,143 @@ public struct AppView: View {
           .frame(maxWidth: 400)
       }
     }
+    .bottomSheet(
+      isPresented: viewStore.binding(
+        get: \.presentEventsBottomSheet,
+        send: AppAction.setEventsBottomSheet
+      ),
+      detents: [.medium()],
+      largestUndimmedDetentIdentifier: .medium,
+      prefersGrabberVisible: true,
+      prefersScrollingExpandsWhenScrolledToEdge: true,
+      prefersEdgeAttachedInCompactHeight: true,
+      selectedDetentIdentifier: .constant(nil),
+      widthFollowsPreferredContentSizeWhenEdgeAttached: true,
+      isModalInPresentation: false,
+      onDismiss: { viewStore.send(.setEventsBottomSheet(false)) },
+      contentView: {
+        VStack {
+          HStack {
+            Text("Events")
+              .foregroundColor(Color(.textPrimary))
+              .font(.title2)
+              .bold()
+
+            Spacer()
+
+            Button(
+              action: { viewStore.send(.setEventsBottomSheet(false)) },
+              label: {
+                Image(systemName: "xmark.circle.fill")
+                  .resizable()
+                  .frame(width: .grid(8), height: .grid(8))
+                  .foregroundColor(Color(.lightGray))
+              }
+            )
+          }
+          .accessibility(addTraits: [.isHeader])
+          .padding(.grid(3))
+
+          List(viewStore.nextRideState.rideEvents, id: \.id) { ride in
+            HStack(alignment: .center, spacing: .grid(2)) {
+              Image(uiImage: Asset.cm.image)
+                .accessibilityHidden(true)
+
+              VStack(alignment: .leading, spacing: .grid(1)) {
+                Text(ride.title)
+                  .multilineTextAlignment(.leading)
+                  .font(.titleTwo)
+                  .foregroundColor(Color(.textPrimary))
+                Text(ride.rideDateAndTime)
+                  .multilineTextAlignment(.leading)
+                  .font(.bodyTwo)
+                  .foregroundColor(Color(.textSecondary))
+              }
+            }
+            .accessibilityElement(children: .combine)
+            .contentShape(Rectangle())
+            .onTapGesture {
+              if let coordinate = ride.coordinate {
+                viewStore.send(
+                  .map(
+                    .focusRideEvent(
+                      Coordinate(latitude: coordinate.latitude, longitude: coordinate.longitude)
+                    )
+                  )
+                )
+              }
+            }
+          }
+          .listStyle(.plain)
+        }
+        .accessibilityAction(.escape) {
+          viewStore.send(.setEventsBottomSheet(false))
+        }
+      }
+    )
     .environment(\.connectivity, viewStore.hasConnectivity)
     .onAppear { viewStore.send(.onAppear) }
     .onDisappear { viewStore.send(.onDisappear) }
   }
+
+  var offlineBanner: some View {
+    Image(systemName: "wifi.slash")
+      .foregroundColor(
+        reduceTransparency
+          ? Color.white
+          : Color(.attention)
+      )
+      .accessibilityRepresentation { viewStore.hasConnectivity ? Text("internet connection available") : Text("internet not available") }
+      .padding()
+      .background(
+        Group {
+          if reduceTransparency {
+            RoundedRectangle(
+              cornerRadius: 12,
+              style: .circular
+            )
+            .fill(reduceTransparency
+              ? Color(.attention)
+              : Color(.attention).opacity(0.8)
+            )
+          } else {
+            Blur()
+          }
+        }
+      )
+  }
+
+  var nextRideBanner: some View {
+    MapOverlayView(
+      store: store.actionless.scope(state: {
+        MapOverlayView.ViewState(
+          isVisible: $0.mapFeatureState.isNextRideBannerVisible,
+          isExpanded: $0.mapFeatureState.isNextRideBannerExpanded
+        )
+      }
+      ),
+      action: { viewStore.send(.map(.focusNextRide(viewStore.nextRideState.nextRide?.coordinate))) },
+      content: {
+        VStack(alignment: .leading, spacing: .grid(1)) {
+          Text(viewStore.state.nextRideState.nextRide?.title ?? "")
+            .multilineTextAlignment(.leading)
+            .font(.titleTwo)
+            .foregroundColor(Color(.textPrimary))
+          Text(viewStore.state.nextRideState.nextRide?.rideDateAndTime ?? "")
+            .multilineTextAlignment(.leading)
+            .font(.bodyTwo)
+            .foregroundColor(Color(.textSecondary))
+        }
+      }
+    )
+    .accessibilityElement(children: .contain)
+    .accessibilityHint(Text(L10n.A11y.Mapfeatureview.Nextridebanner.hint))
+    .accessibilityLabel(Text(L10n.A11y.Mapfeatureview.Nextridebanner.label))
+  }
 }
 
 // MARK: Preview
+
 struct AppView_Previews: PreviewProvider {
   static var previews: some View {
     AppView(store: Store<AppState, AppAction>(

--- a/CriticalMapsKit/Sources/AppFeature/AppView.swift
+++ b/CriticalMapsKit/Sources/AppFeature/AppView.swift
@@ -31,7 +31,29 @@ public struct AppView: View {
         )
       )
       .edgesIgnoringSafeArea(.vertical)
-      
+
+      VStack(alignment: .leading) {
+        if viewStore.state.mapFeatureState.isNextRideBannerVisible {
+          nextRideBanner
+            .contextMenu {
+              Button(
+                action: { viewStore.send(.setEventsBottomSheet(!viewStore.presentEventsBottomSheet)) },
+                label: {
+                  let title = viewStore.presentEventsBottomSheet ? L10n.Map.NextRideEvents.hideAll : L10n.Map.NextRideEvents.showAll
+                  Label(title, systemImage: "list.bullet")
+                }
+              )
+            }
+        }
+
+        offlineBanner
+          .clipShape(Circle())
+          .opacity(viewStore.hasConnectivity ? 0 : 1)
+          .accessibleAnimation(.easeOut, value: viewStore.hasConnectivity)
+      }
+      .padding(.top, .grid(2))
+      .padding(.horizontal)
+
       VStack {
         Spacer()
         

--- a/CriticalMapsKit/Sources/L10n/L10n.swift
+++ b/CriticalMapsKit/Sources/L10n/L10n.swift
@@ -20,6 +20,7 @@ public enum L10n {
       /// Chat input textfield
       public static let label = L10n.tr("Localizable", "a11y.chatInput.label")
     }
+
     public enum General {
       /// Off
       public static let off = L10n.tr("Localizable", "a11y.general.off")
@@ -28,6 +29,7 @@ public enum L10n {
       /// selected
       public static let selected = L10n.tr("Localizable", "a11y.general.selected")
     }
+
     public enum Mapfeatureview {
       public enum Nextridebanner {
         /// Shows the next critical mass event closest to your location
@@ -36,6 +38,7 @@ public enum L10n {
         public static let label = L10n.tr("Localizable", "a11y.mapfeatureview.nextridebanner.label")
       }
     }
+
     public enum Usertrackingbutton {
       /// Don't follow
       public static let dontFollow = L10n.tr("Localizable", "a11y.usertrackingbutton.dontFollow")
@@ -64,10 +67,11 @@ public enum L10n {
       /// The message could not be sent. Please try again.
       public static let error = L10n.tr("Localizable", "chat.send.error")
     }
+
     public enum Unreadbutton {
       /// %@ unread messages
       public static func accessibilityvalue(_ p1: Any) -> String {
-        return L10n.tr("Localizable", "chat.unreadbutton.accessibilityvalue", String(describing: p1))
+        L10n.tr("Localizable", "chat.unreadbutton.accessibilityvalue", String(describing: p1))
       }
     }
   }
@@ -93,11 +97,11 @@ public enum L10n {
 
   public enum Location {
     public enum Alert {
-      /// Bitte geben Sie uns in den Einstellungen Zugriff auf Ihren Standort.
+      /// Please give us access to your location in settings.
       public static let provideAccessToLocationService = L10n.tr("Localizable", "location.alert.provideAccessToLocationService")
-      /// Die Standortnutzung macht diese App besser. Bitte geben Sie uns Zugang.
+      /// Location usage makes this app better. Please give us access.
       public static let provideAuth = L10n.tr("Localizable", "location.alert.provideAuth")
-      /// Ortungsdienste sind deaktiviert.
+      /// Location services are disabled.
       public static let serviceIsOff = L10n.tr("Localizable", "location.alert.serviceIsOff")
     }
   }
@@ -117,6 +121,7 @@ public enum L10n {
         public static let on = L10n.tr("Localizable", "map.headingbutton.accessibilityvalue.on")
       }
     }
+
     public enum Layer {
       /// Critical Maps needs to use your GPS to show the map with other active user
       public static let info = L10n.tr("Localizable", "map.layer.info")
@@ -127,10 +132,12 @@ public enum L10n {
         public static let title = L10n.tr("Localizable", "map.layer.info.title")
       }
     }
+
     public enum LocationButton {
       /// locating
       public static let label = L10n.tr("Localizable", "map.locationButton.label")
     }
+
     public enum Menu {
       /// Route
       public static let route = L10n.tr("Localizable", "map.menu.route")
@@ -138,6 +145,13 @@ public enum L10n {
       public static let share = L10n.tr("Localizable", "map.menu.share")
       /// Next event
       public static let title = L10n.tr("Localizable", "map.menu.title")
+    }
+
+    public enum NextRideEvents {
+      /// Hide events
+      public static let hideAll = L10n.tr("Localizable", "map.nextRideEvents.hideAll")
+      /// Show events
+      public static let showAll = L10n.tr("Localizable", "map.nextRideEvents.showAll")
     }
   }
 
@@ -152,22 +166,23 @@ public enum L10n {
       /// Refrain from driving in the opposite lane.
       public static let contraflow = L10n.tr("Localizable", "rules.text.contraflow")
       /// Protect motorists from themselves by corking!
-      /// 
+      ///
       /// To maintain the cohesion of the group, block traffic from side roads so that the mass can freely proceed through red lights without interruptions.
       public static let cork = L10n.tr("Localizable", "rules.text.cork")
       /// When driving in the front: No speeding!
-      /// 
+      ///
       /// When driving in the rear: Close gaps!
       public static let gently = L10n.tr("Localizable", "rules.text.gently")
       /// When you arrive at a red light while driving as part of the head of the mass, be sure to stop when the traffic light shows red.
       public static let green = L10n.tr("Localizable", "rules.text.green")
       /// Enjoy reclaimed streets. Check out the Sound Bikes. Chat with motorists and pedestrian to let them know what's going on.
-      /// 
+      ///
       /// And most importantly: Have fun!
       public static let haveFun = L10n.tr("Localizable", "rules.text.haveFun")
       /// Don't allow yourself to be provoked. Be friendly to the police, motorists and everybody else, even if they are not.
       public static let stayLoose = L10n.tr("Localizable", "rules.text.stayLoose")
     }
+
     public enum Title {
       /// No hard stops!
       public static let brake = L10n.tr("Localizable", "rules.title.brake")
@@ -203,8 +218,9 @@ public enum L10n {
     public static let eventSearchRadius = L10n.tr("Localizable", "settings.eventSearchRadius")
     /// %@ km
     public static func eventSearchRadiusDistance(_ p1: Any) -> String {
-      return L10n.tr("Localizable", "settings.eventSearchRadiusDistance", String(describing: p1))
+      L10n.tr("Localizable", "settings.eventSearchRadiusDistance", String(describing: p1))
     }
+
     /// Event Settings
     public static let eventSettings = L10n.tr("Localizable", "settings.eventSettings")
     /// Event Notifications
@@ -249,6 +265,7 @@ public enum L10n {
       /// Missing a mass?
       public static let title = L10n.tr("Localizable", "settings.criticalMassDotIn.title")
     }
+
     public enum Friends {
       /// added
       public static let addFriendDescription = L10n.tr("Localizable", "settings.friends.addFriendDescription")
@@ -259,12 +276,14 @@ public enum L10n {
       /// Show ID
       public static let showID = L10n.tr("Localizable", "settings.friends.showID")
     }
+
     public enum Observationmode {
       /// If you don’t take part yourself, but want to follow the Critical Mass.
       public static let detail = L10n.tr("Localizable", "settings.observationmode.detail")
       /// Observation Mode
       public static let title = L10n.tr("Localizable", "settings.observationmode.title")
     }
+
     public enum Opensource {
       /// View Repository
       public static let action = L10n.tr("Localizable", "settings.opensource.action")
@@ -273,10 +292,12 @@ public enum L10n {
       /// Do you miss features or want to fix a bug?
       public static let title = L10n.tr("Localizable", "settings.opensource.title")
     }
+
     public enum Section {
       /// Info
       public static let info = L10n.tr("Localizable", "settings.section.info")
     }
+
     public enum Theme {
       /// Appearance
       public static let appearance = L10n.tr("Localizable", "settings.theme.appearance")
@@ -287,6 +308,7 @@ public enum L10n {
       /// System
       public static let system = L10n.tr("Localizable", "settings.theme.system")
     }
+
     public enum Translate {
       /// crowdin.com
       public static let link = L10n.tr("Localizable", "settings.translate.link")
@@ -308,6 +330,7 @@ public enum L10n {
     }
   }
 }
+
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name vertical_whitespace_opening_braces
 
@@ -324,10 +347,11 @@ extension L10n {
 private final class BundleToken {
   static let bundle: Bundle = {
     #if SWIFT_PACKAGE
-    return Bundle.module
+      return Bundle.module
     #else
-    return Bundle(for: BundleToken.self)
+      return Bundle(for: BundleToken.self)
     #endif
   }()
 }
+
 // swiftlint:enable convenience_type

--- a/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
@@ -51,6 +51,8 @@
 
 "location.alert.provideAccessToLocationService" = "Bitte geben Sie uns in den Einstellungen Zugriff auf Ihren Standort.";
 
+"map.nextRideEvents.showAll" = "Alle Events anzeigen";
+"map.nextRideEvents.hideAll" = "Alle Events verbergen";
 
 "map.headingbutton.accessibilitylabel" = "Tracking";
 

--- a/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
@@ -52,6 +52,9 @@
 "location.alert.provideAccessToLocationService" = "Please give us access to your location in settings.";
 
 
+"map.nextRideEvents.showAll" = "Show events";
+"map.nextRideEvents.hideAll" = "Hide events";
+
 "map.headingbutton.accessibilitylabel" = "Tracking";
 
 

--- a/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
@@ -52,6 +52,9 @@
 "location.alert.provideAccessToLocationService" = "Por favor, danos acceso a tu ubicación en ajustes.";
 
 
+"map.nextRideEvents.showAll" = "Alle Events anzeigen";
+"map.nextRideEvents.hideAll" = "Alle Events verbergen";
+
 "map.headingbutton.accessibilitylabel" = "Tracking";
 
 

--- a/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
@@ -52,6 +52,9 @@
 "location.alert.provideAccessToLocationService" = "Veuillez nous donner accès à votre localisation dans les paramètres.";
 
 
+"map.nextRideEvents.showAll" = "Alle Events anzeigen";
+"map.nextRideEvents.hideAll" = "Alle Events verbergen";
+
 "map.headingbutton.accessibilitylabel" = "Tracking";
 
 

--- a/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
@@ -52,6 +52,9 @@
 "location.alert.provideAccessToLocationService" = "Please give us access to your location in settings.";
 
 
+"map.nextRideEvents.showAll" = "Alle Events anzeigen";
+"map.nextRideEvents.hideAll" = "Alle Events verbergen";
+
 "map.headingbutton.accessibilitylabel" = "Tracking";
 
 

--- a/CriticalMapsKit/Sources/MapFeature/MapFeatureCore.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapFeatureCore.swift
@@ -36,7 +36,7 @@ public struct MapFeatureState: Equatable {
     self.alert = alert
     self.isRequestingCurrentLocation = isRequestingCurrentLocation
     self.location = location
-    self.riderLocations = riders
+    riderLocations = riders
     self.userTrackingMode = userTrackingMode
     self.nextRide = nextRide
     self.centerRegion = centerRegion
@@ -238,22 +238,22 @@ private let locationManagerReducer = Reducer<MapFeatureState, LocationManager.Ac
   }
 }
 
-
 // MARK: - Helper
+
 extension LocationManager {
   /// Configures the LocationManager
-  func setup(id: AnyHashable) -> Effect<Never, Never> {
-      set(
-        .init(
-            activityType: .otherNavigation,
-            allowsBackgroundLocationUpdates: true,
-            desiredAccuracy: kCLLocationAccuracyBestForNavigation,
-            distanceFilter: nil,
-            headingFilter: nil,
-            pausesLocationUpdatesAutomatically: false,
-            showsBackgroundLocationIndicator: true
-        )
+  func setup(id _: AnyHashable) -> Effect<Never, Never> {
+    set(
+      .init(
+        activityType: .otherNavigation,
+        allowsBackgroundLocationUpdates: true,
+        desiredAccuracy: kCLLocationAccuracyBestForNavigation,
+        distanceFilter: nil,
+        headingFilter: nil,
+        pausesLocationUpdatesAutomatically: false,
+        showsBackgroundLocationIndicator: true
       )
+    )
   }
 }
 

--- a/CriticalMapsKit/Sources/MapFeature/MapFeatureView.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapFeatureView.swift
@@ -45,21 +45,6 @@ public struct MapFeatureView: View {
         }
       )
       .edgesIgnoringSafeArea(.all)
-      
-      VStack {
-        if viewStore.isNextRideBannerVisible {
-          nextRideBanner
-        } else {
-          EmptyView()
-        }
-        
-        offlineBanner
-          .clipShape(Circle())
-          .opacity(isConnected ? 0 : 1)
-          .accessibleAnimation(.easeOut, value: isConnected)
-      }
-      .padding(.top, .grid(12))
-      .padding(.horizontal)
     }
     .sheet(
       isPresented: viewStore.binding(
@@ -72,61 +57,10 @@ public struct MapFeatureView: View {
       }
     )
   }
-  
-  var offlineBanner: some View {
-    Image(systemName: "wifi.slash")
-      .foregroundColor(
-        reduceTransparency
-        ? Color.white
-        : Color(.attention)
-      )
-      .accessibilityRepresentation { isConnected ? Text("internet connection available") : Text("internet not available") }
-      .padding()
-      .background(
-        Group {
-          if reduceTransparency {
-            RoundedRectangle(
-              cornerRadius: 12,
-              style: .circular
-            )
-            .fill(reduceTransparency
-                ? Color(.attention)
-                : Color(.attention).opacity(0.8)
-            )
-          } else {
-            Blur()
-          }
-        }
-      )
-  }
-  
-  var nextRideBanner: some View {
-    MapOverlayView(
-      store: store.actionless.scope(state: {
-        MapOverlayView.ViewState(
-          isVisible: $0.isNextRideBannerVisible,
-          isExpanded: $0.isNextRideBannerExpanded
-        )}
-      ),
-      action: { viewStore.send(.focusNextRide) },
-      content: {
-        VStack(alignment: .leading) {
-          Text(viewStore.nextRide?.title ?? "")
-            .font(.titleTwo)
-            .foregroundColor(Color(.textPrimary))
-          Text(viewStore.nextRide?.rideDateAndTime ?? "")
-            .font(.bodyTwo)
-            .foregroundColor(Color(.textSecondary))
-        }
-      }
-    )
-      .accessibilityElement(children: .contain)
-      .accessibilityHint(Text(L10n.A11y.Mapfeatureview.Nextridebanner.hint))
-      .accessibilityLabel(Text(L10n.A11y.Mapfeatureview.Nextridebanner.label))
-  }
 }
 
 // MARK: Preview
+
 struct MapFeatureView_Previews: PreviewProvider {
   static var previews: some View {
     MapFeatureView(

--- a/CriticalMapsKit/Sources/MapFeature/MapFeatureView.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapFeatureView.swift
@@ -28,8 +28,13 @@ public struct MapFeatureView: View {
         ),
         shouldAnimateUserTrackingMode: viewStore.shouldAnimateTrackingMode,
         nextRide: viewStore.nextRide,
+        rideEvents: viewStore.rideEvents,
         centerRegion: viewStore.binding(
           get: \.centerRegion,
+          send: MapFeatureAction.updateCenterRegion
+        ),
+        centerEventRegion: viewStore.binding(
+          get: \.eventCenter,
           send: MapFeatureAction.updateCenterRegion
         ),
         mapMenuShareEventHandler: {

--- a/CriticalMapsKit/Sources/MapFeature/MapFeatureView.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapFeatureView.swift
@@ -12,7 +12,7 @@ public struct MapFeatureView: View {
   
   public init(store: Store<MapFeatureState, MapFeatureAction>) {
     self.store = store
-    self.viewStore = ViewStore(store)
+    viewStore = ViewStore(store)
   }
   
   let store: Store<MapFeatureState, MapFeatureAction>

--- a/CriticalMapsKit/Sources/MapFeature/MapOverlayView.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapOverlayView.swift
@@ -32,14 +32,14 @@ public struct MapOverlayView<Content>: View where Content: View {
     @ViewBuilder content: @escaping () -> Content
   ) {
     self.store = store
-    self.viewStore = ViewStore(store)
+    viewStore = ViewStore(store)
     self.action = action
     self.content = content
   }
   
   public var body: some View {
     Button(
-      action: { action() },
+      action: action,
       label: {
         HStack {
           Image(uiImage: Asset.cm.image)
@@ -54,38 +54,39 @@ public struct MapOverlayView<Content>: View where Content: View {
               )
           }
         }
-        .padding(.horizontal, isExpanded ? 8 : 0)
+        .padding(.horizontal, isExpanded ? .grid(2) : 0)
       }
     )
-      .frame(minWidth: 50, minHeight: 50)
-      .foregroundColor(reduceTransparency ? .white : Color(.textPrimary))
-      .background(
-        Group {
-          if reduceTransparency {
-            RoundedRectangle(
-              cornerRadius: 12,
-              style: .circular
-            )
-            .fill(Color(.backgroundPrimary))
-          } else {
-            Blur()
-              .cornerRadius(12)
-          }
+    .frame(minWidth: 50, minHeight: 50)
+    .foregroundColor(reduceTransparency ? .white : Color(.textPrimary))
+    .background(
+      Group {
+        if reduceTransparency {
+          RoundedRectangle(
+            cornerRadius: 12,
+            style: .circular
+          )
+          .fill(Color(.backgroundPrimary))
+        } else {
+          Blur()
+            .cornerRadius(12)
         }
-      )
-      .transition(.scale.animation(reduceMotion ? nil : .easeOut(duration: 0.2)))
-      .onChange(of: viewStore.isExpanded, perform: { newValue in
-        let updateAction: () -> Void = { self.isExpanded = newValue }
-        reduceMotion ? updateAction() : withAnimation { updateAction() }
-      })
-      .onChange(of: viewStore.isVisible, perform: { newValue in
-        let updateAction: () -> Void = { self.isVisible = newValue }
-        reduceMotion ? updateAction() : withAnimation { updateAction() }
-      })
+      }
+    )
+    .transition(.scale.animation(reduceMotion ? nil : .easeOut(duration: 0.2)))
+    .onChange(of: viewStore.isExpanded, perform: { newValue in
+      let updateAction: () -> Void = { self.isExpanded = newValue }
+      reduceMotion ? updateAction() : withAnimation { updateAction() }
+    })
+    .onChange(of: viewStore.isVisible, perform: { newValue in
+      let updateAction: () -> Void = { self.isVisible = newValue }
+      reduceMotion ? updateAction() : withAnimation { updateAction() }
+    })
   }
 }
 
 // MARK: Preview
+
 struct MapOverlayView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
@@ -93,11 +94,12 @@ struct MapOverlayView_Previews: PreviewProvider {
         store: Store<MapFeatureState, Never>(
           initialState: .init(riders: [], userTrackingMode: .init(userTrackingMode: .follow)),
           reducer: .empty,
-          environment: ())
-          .actionless
-          .scope(state: { _ in
-            MapOverlayView.ViewState(isVisible: true, isExpanded: true)
-          }
+          environment: ()
+        )
+        .actionless
+        .scope(state: { _ in
+          MapOverlayView.ViewState(isVisible: true, isExpanded: true)
+        }
         ),
         action: {},
         content: {
@@ -112,11 +114,12 @@ struct MapOverlayView_Previews: PreviewProvider {
         store: Store<MapFeatureState, Never>(
           initialState: .init(riders: [], userTrackingMode: .init(userTrackingMode: .follow)),
           reducer: .empty,
-          environment: ())
-          .actionless
-          .scope(state: { _ in
-            MapOverlayView.ViewState(isVisible: true, isExpanded: true)
-          }
+          environment: ()
+        )
+        .actionless
+        .scope(state: { _ in
+          MapOverlayView.ViewState(isVisible: true, isExpanded: true)
+        }
         ),
         action: {},
         content: {
@@ -131,11 +134,12 @@ struct MapOverlayView_Previews: PreviewProvider {
         store: Store<MapFeatureState, Never>(
           initialState: .init(riders: [], userTrackingMode: .init(userTrackingMode: .follow)),
           reducer: .empty,
-          environment: ())
-          .actionless
-          .scope(state: { _ in
-            MapOverlayView.ViewState(isVisible: true, isExpanded: false)
-          }
+          environment: ()
+        )
+        .actionless
+        .scope(state: { _ in
+          MapOverlayView.ViewState(isVisible: true, isExpanded: false)
+        }
         ),
         action: {},
         content: {}

--- a/CriticalMapsKit/Sources/MapFeature/MapView.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapView.swift
@@ -113,14 +113,14 @@ final class MapCoordinator: NSObject, MKMapViewDelegate {
   init(_ parent: MapView) {
     self.parent = parent
   }
-  
-  func mapView(_ mapView: MKMapView, didChange mode: MKUserTrackingMode, animated: Bool) {
+
+  func mapView(_: MKMapView, didChange mode: MKUserTrackingMode, animated _: Bool) {
     parent.userTrackingMode = mode
   }
     
   func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
     guard annotation is MKUserLocation == false else {
-        return nil
+      return nil
     }
     if annotation is RiderAnnotation {
       let view = mapView.dequeueReusableAnnotationView(
@@ -135,8 +135,8 @@ final class MapCoordinator: NSObject, MKMapViewDelegate {
         withIdentifier: CMMarkerAnnotationView.reuseIdentifier,
         for: annotation
       ) as? CMMarkerAnnotationView
-      view?.shareEventClosure = self.parent.mapMenuShareEventHandler
-      view?.routeEventClosure = self.parent.mapMenuRouteEventHandler
+      view?.shareEventClosure = parent.mapMenuShareEventHandler
+      view?.routeEventClosure = parent.mapMenuRouteEventHandler
       return view
     }
     

--- a/CriticalMapsKit/Sources/NextRideFeature/CriticalMassAnnotation.swift
+++ b/CriticalMapsKit/Sources/NextRideFeature/CriticalMassAnnotation.swift
@@ -5,9 +5,9 @@ import SharedModels
 
 /// Map annotation to annotate the next ride on a map.
 public final class CriticalMassAnnotation: NSObject, MKAnnotation {
-  let ride: Ride
-  let rideCoordinate: CLLocationCoordinate2D
-  
+  public let ride: Ride
+  let rideCoordinate: Coordinate
+
   public init?(ride: Ride) {
     guard let rideCoordinate = ride.coordinate else {
       return nil
@@ -22,7 +22,7 @@ public final class CriticalMassAnnotation: NSObject, MKAnnotation {
   }
   
   @objc public dynamic var coordinate: CLLocationCoordinate2D {
-    rideCoordinate
+    rideCoordinate.asCLLocationCoordinate
   }
   
   public var subtitle: String? {

--- a/CriticalMapsKit/Sources/NextRideFeature/NextRideCore.swift
+++ b/CriticalMapsKit/Sources/NextRideFeature/NextRideCore.swift
@@ -7,6 +7,7 @@ import SharedModels
 import UserDefaultsClient
 
 // MARK: State
+
 public struct NextRideState: Equatable {
   public init(nextRide: Ride? = nil, hasConnectivity: Bool = true) {
     self.nextRide = nextRide
@@ -18,16 +19,16 @@ public struct NextRideState: Equatable {
   public var rideEvents: [Ride] = []
 }
 
-
 // MARK: Actions
+
 public enum NextRideAction: Equatable {
   case getNextRide(Coordinate)
   case nextRideResponse(Result<[Ride], NextRideService.Failure>)
   case setNextRide(Ride)
 }
 
-
 // MARK: Environment
+
 public struct NextRideEnvironment {
   public init(
     service: NextRideService = .live(),
@@ -37,7 +38,7 @@ public struct NextRideEnvironment {
     coordinateObfuscator: CoordinateObfuscator = .live
   ) {
     self.service = service
-    self.userDefaultsClient = store
+    userDefaultsClient = store
     self.now = now
     self.mainQueue = mainQueue
     self.coordinateObfuscator = coordinateObfuscator
@@ -50,12 +51,12 @@ public struct NextRideEnvironment {
   let coordinateObfuscator: CoordinateObfuscator
 }
 
-
 // MARK: Reducer
+
 /// Reducer handling next ride feature actions
 public let nextRideReducer = Reducer<NextRideState, NextRideAction, NextRideEnvironment> { state, action, env in
   switch action {
-  case .getNextRide(let coordinate):
+  case let .getNextRide(coordinate):
     guard env.userDefaultsClient.rideEventSettings().isEnabled else {
       logger.debug("NextRide featue is disabled")
       return .none
@@ -77,10 +78,10 @@ public let nextRideReducer = Reducer<NextRideState, NextRideAction, NextRideEnvi
       env.userDefaultsClient.rideEventSettings().eventDistance.rawValue,
       requestRidesInMonth
     )
-      .receive(on: env.mainQueue)
-      .catchToEffect()
-      .map(NextRideAction.nextRideResponse)
-    
+    .receive(on: env.mainQueue)
+    .catchToEffect()
+    .map(NextRideAction.nextRideResponse)
+
   case let .nextRideResponse(.failure(error)):
     logger.error("Get next ride failed 🛑 with error: \(error)")
     return .none
@@ -124,6 +125,8 @@ public let nextRideReducer = Reducer<NextRideState, NextRideAction, NextRideEnvi
   }
 }
 
+// MARK: Helper
+
 enum EventError: Error, LocalizedError {
   case eventsAreNotEnabled
   case invalidDateError
@@ -132,7 +135,6 @@ enum EventError: Error, LocalizedError {
   case rideTypeIsFiltered
   case rideDisabled
 }
-
 
 private func queryMonth(in date: () -> Date = Date.init, calendar: Calendar = .current) -> Int {
   let currentMonthOfFallback = calendar.dateComponents([.month], from: date()).month ?? 0

--- a/CriticalMapsKit/Sources/NextRideFeature/NextRideCore.swift
+++ b/CriticalMapsKit/Sources/NextRideFeature/NextRideCore.swift
@@ -15,6 +15,7 @@ public struct NextRideState: Equatable {
   
   public var hasConnectivity: Bool
   public var nextRide: Ride?
+  public var rideEvents: [Ride] = []
 }
 
 
@@ -92,6 +93,9 @@ public let nextRideReducer = Reducer<NextRideState, NextRideAction, NextRideEnvi
       logger.info("No upcoming events for filter selection rideType")
       return .none
     }
+
+    state.rideEvents = rides.sortByDateAndFilterBeforeDate(env.now)
+
     // Sort rides by date and pick the first one with a date greater than now
     let ride = rides // swiftlint:disable:this sorted_first_last
       .lazy
@@ -145,4 +149,12 @@ private func queryMonth(in date: () -> Date = Date.init, calendar: Calendar = .c
   }
   
   return max(currentMonthOfFallback, month)
+}
+
+public extension Array where Element == Ride {
+  func sortByDateAndFilterBeforeDate(_ now: () -> Date) -> Self {
+    lazy
+      .sorted(by: \.dateTime)
+      .filter { $0.dateTime > now() }
+  }
 }

--- a/CriticalMapsKit/Sources/SettingsFeature/Resources/Acknowledgements.plist
+++ b/CriticalMapsKit/Sources/SettingsFeature/Resources/Acknowledgements.plist
@@ -14,7 +14,7 @@
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>Copyright (c) 2015-2021 Vincent Tourraine (https://www.vtourraine.net)
+			<string>Copyright (c) 2015-2022 Vincent Tourraine (https://www.vtourraine.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -26,6 +26,37 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			<string>MIT License</string>
 			<key>Title</key>
 			<string>AcknowList</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+		<dict>
+			<key>FooterText</key>
+			<string>MIT License
+
+Copyright (c) 2021 Adam Foot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</string>
+			<key>License</key>
+			<string>MIT License</string>
+			<key>Title</key>
+			<string>BottomSheet</string>
 			<key>Type</key>
 			<string>PSGroupSpecifier</string>
 		</dict>

--- a/CriticalMapsKit/Sources/SharedModels/NextRideFeature/Ride.swift
+++ b/CriticalMapsKit/Sources/SharedModels/NextRideFeature/Ride.swift
@@ -56,11 +56,11 @@ public struct Ride: Hashable, Codable, Identifiable {
 }
 
 public extension Ride {
-  var coordinate: CLLocationCoordinate2D? {
+  var coordinate: Coordinate? {
     guard let lat = latitude, let lng = longitude else {
       return nil
     }
-    return CLLocationCoordinate2D(latitude: lat, longitude: lng)
+    return Coordinate(latitude: lat, longitude: lng)
   }
   
   var titleAndTime: String {
@@ -94,7 +94,7 @@ public extension Ride {
       debugPrint("Coordinte is nil")
       return
     }
-    let placemark = MKPlacemark(coordinate: coordinate, addressDictionary: nil)
+    let placemark = MKPlacemark(coordinate: coordinate.asCLLocationCoordinate, addressDictionary: nil)
     let mapItem = MKMapItem(placemark: placemark)
     mapItem.name = location
     mapItem.openInMaps(launchOptions: options)

--- a/CriticalMapsKit/Sources/Styleguide/Images.swift
+++ b/CriticalMapsKit/Sources/Styleguide/Images.swift
@@ -20,6 +20,7 @@ public typealias AssetImageTypeAlias = ImageAsset.Image
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 public enum Asset {
   public static let chatEmpty = ImageAsset(name: "chat.empty")
+  public static let chat = ImageAsset(name: "chat")
   public static let brake = ImageAsset(name: "Brake")
   public static let corken = ImageAsset(name: "Corken")
   public static let friendly = ImageAsset(name: "Friendly")
@@ -37,6 +38,7 @@ public enum Asset {
   public static let twitterEmpty = ImageAsset(name: "twitter.empty")
   public static let error = ImageAsset(name: "error")
 }
+
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 // MARK: - Implementation Details
@@ -45,21 +47,21 @@ public struct ImageAsset {
   public fileprivate(set) var name: String
 
   #if os(macOS)
-  public typealias Image = NSImage
+    public typealias Image = NSImage
   #elseif os(iOS) || os(tvOS) || os(watchOS)
-  public typealias Image = UIImage
+    public typealias Image = UIImage
   #endif
 
   @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
   public var image: Image {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
-    let image = Image(named: name, in: bundle, compatibleWith: nil)
+      let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let name = NSImage.Name(self.name)
-    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
+      let name = NSImage.Name(name)
+      let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
-    let image = Image(named: name)
+      let image = Image(named: name)
     #endif
     guard let result = image else {
       fatalError("Unable to load image asset named \(name).")
@@ -68,29 +70,29 @@ public struct ImageAsset {
   }
 
   #if os(iOS) || os(tvOS)
-  @available(iOS 8.0, tvOS 9.0, *)
-  public func image(compatibleWith traitCollection: UITraitCollection) -> Image {
-    let bundle = BundleToken.bundle
-    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
-      fatalError("Unable to load image asset named \(name).")
+    @available(iOS 8.0, tvOS 9.0, *)
+    public func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+      let bundle = BundleToken.bundle
+      guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+        fatalError("Unable to load image asset named \(name).")
+      }
+      return result
     }
-    return result
-  }
   #endif
 }
 
 public extension ImageAsset.Image {
   @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
   @available(macOS, deprecated,
-    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
+             message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
   convenience init!(asset: ImageAsset) {
     #if os(iOS) || os(tvOS)
-    let bundle = BundleToken.bundle
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+      let bundle = BundleToken.bundle
+      self.init(named: asset.name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    self.init(named: NSImage.Name(asset.name))
+      self.init(named: NSImage.Name(asset.name))
     #elseif os(watchOS)
-    self.init(named: asset.name)
+      self.init(named: asset.name)
     #endif
   }
 }
@@ -99,10 +101,11 @@ public extension ImageAsset.Image {
 private final class BundleToken {
   static let bundle: Bundle = {
     #if SWIFT_PACKAGE
-    return Bundle.module
+      return Bundle.module
     #else
-    return Bundle(for: BundleToken.self)
+      return Bundle(for: BundleToken.self)
     #endif
   }()
 }
+
 // swiftlint:enable convenience_type

--- a/CriticalMapsKit/Tests/AppFeatureTests/AppFeatureCoreTests.swift
+++ b/CriticalMapsKit/Tests/AppFeatureTests/AppFeatureCoreTests.swift
@@ -529,8 +529,139 @@ class AppFeatureTests: XCTestCase {
       state.chatMessageBadgeCount = 0
     }
   }
-}
 
+  func test_actionSetEventsBottomSheet_setsValue_andMapFeatureRideEvents() {
+    var appState = AppState()
+    let events = [
+      Ride(
+        id: 1,
+        slug: nil,
+        title: "Next Ride",
+        description: nil,
+        dateTime: Date(timeIntervalSince1970: 1_234_340_120),
+        location: nil,
+        latitude: nil,
+        longitude: nil,
+        estimatedParticipants: 123,
+        estimatedDistance: 312,
+        estimatedDuration: 3,
+        enabled: true,
+        disabledReason: nil,
+        disabledReasonMessage: nil,
+        rideType: .alleycat
+      ),
+      Ride(
+        id: 2,
+        slug: nil,
+        title: "Next Ride",
+        description: nil,
+        dateTime: Date(timeIntervalSince1970: 1_234_340_120),
+        location: nil,
+        latitude: nil,
+        longitude: nil,
+        estimatedParticipants: 123,
+        estimatedDistance: 312,
+        estimatedDuration: 3,
+        enabled: true,
+        disabledReason: nil,
+        disabledReasonMessage: nil,
+        rideType: .criticalMass
+      ),
+    ]
+    appState.nextRideState.rideEvents = events
+
+    let store = TestStore(
+      initialState: appState,
+      reducer: appReducer,
+      environment: AppEnvironment(
+        uiApplicationClient: .noop,
+        setUserInterfaceStyle: { _ in .none },
+        pathMonitorClient: .satisfied
+      )
+    )
+
+    store.send(.setEventsBottomSheet(true)) {
+      $0.presentEventsBottomSheet = true
+      $0.mapFeatureState.rideEvents = events
+    }
+  }
+
+  func test_actionSetEventsBottomSheet_setsValue_andSetEmptyMapFeatureRideEvents() {
+    var appState = AppState()
+    let events = [
+      Ride(
+        id: 1,
+        slug: nil,
+        title: "Next Ride",
+        description: nil,
+        dateTime: Date(timeIntervalSince1970: 1_234_340_120),
+        location: nil,
+        latitude: nil,
+        longitude: nil,
+        estimatedParticipants: 123,
+        estimatedDistance: 312,
+        estimatedDuration: 3,
+        enabled: true,
+        disabledReason: nil,
+        disabledReasonMessage: nil,
+        rideType: .alleycat
+      ),
+      Ride(
+        id: 2,
+        slug: nil,
+        title: "Next Ride",
+        description: nil,
+        dateTime: Date(timeIntervalSince1970: 1_234_340_120),
+        location: nil,
+        latitude: nil,
+        longitude: nil,
+        estimatedParticipants: 123,
+        estimatedDistance: 312,
+        estimatedDuration: 3,
+        enabled: true,
+        disabledReason: nil,
+        disabledReasonMessage: nil,
+        rideType: .criticalMass
+      ),
+    ]
+    appState.mapFeatureState.rideEvents = events
+
+    let store = TestStore(
+      initialState: appState,
+      reducer: appReducer,
+      environment: AppEnvironment(
+        uiApplicationClient: .noop,
+        setUserInterfaceStyle: { _ in .none },
+        pathMonitorClient: .satisfied
+      )
+    )
+
+    store.send(.setEventsBottomSheet(false)) {
+      $0.presentEventsBottomSheet = false
+      $0.mapFeatureState.rideEvents = []
+    }
+  }
+
+  func test_focuesNextRide_whenAllEventsArePresented_shouldHideAllEventsBotttomSheet() {
+    var appState = AppState()
+    appState.presentEventsBottomSheet = true
+
+    let store = TestStore(
+      initialState: appState,
+      reducer: appReducer,
+      environment: AppEnvironment(
+        uiApplicationClient: .noop,
+        setUserInterfaceStyle: { _ in .none },
+        pathMonitorClient: .satisfied
+      )
+    )
+
+    store.send(.map(.focusNextRide(nil)))
+    store.receive(.setEventsBottomSheet(false)) {
+      $0.presentEventsBottomSheet = false
+    }
+  }
+}
 
 // MARK: Helper
 let testError = NSError(domain: "", code: 1, userInfo: [:])

--- a/CriticalMapsKit/Tests/AppFeatureTests/AppFeatureCoreTests.swift
+++ b/CriticalMapsKit/Tests/AppFeatureTests/AppFeatureCoreTests.swift
@@ -44,11 +44,11 @@ class AppFeatureTests: XCTestCase {
       pathMonitorClient: .satisfied
     )
     environment.fileClient.load = { _ in
-        .init(
-          value: try! JSONEncoder().encode(
-            UserSettings()
-          )
+      .init(
+        value: try! JSONEncoder().encode(
+          UserSettings()
         )
+      )
     }
     
     let store = TestStore(
@@ -126,7 +126,7 @@ class AppFeatureTests: XCTestCase {
     locationManager.authorizationStatus = { .notDetermined }
     locationManager.locationServicesEnabled = { true }
     locationManager.requestAlwaysAuthorization = { .fireAndForget {
-        didRequestAlwaysAuthorization = true
+      didRequestAlwaysAuthorization = true
     } }
     locationManager.requestLocation = { .fireAndForget { didRequestLocation = true } }
     locationManager.set = { _ in setSubject.eraseToEffect() }
@@ -144,11 +144,11 @@ class AppFeatureTests: XCTestCase {
       pathMonitorClient: .satisfied
     )
     environment.fileClient.load = { _ in
-        .init(
-          value: try! JSONEncoder().encode(
-            UserSettings()
-          )
+      .init(
+        value: try! JSONEncoder().encode(
+          UserSettings()
         )
+      )
     }
     
     var appState = AppState()
@@ -224,15 +224,15 @@ class AppFeatureTests: XCTestCase {
     serviceSubject.send(completion: .finished)
     nextRideSubject.send(completion: .finished)
     testScheduler.advance()
-}
-  
+  }
+
   func test_onAppearWithEnabledLocationServicesRideEventDisabled_shouldNotRequestNextRide() {
     let setSubject = PassthroughSubject<Never, Never>()
     var didRequestAlwaysAuthorization = false
     var didRequestLocation = false
     let locationManagerSubject = PassthroughSubject<LocationManager.Action, Never>()
     let serviceSubject = PassthroughSubject<LocationAndChatMessages, NSError>()
-    
+
     let currentLocation = Location(
       altitude: 0,
       coordinate: CLLocationCoordinate2D(latitude: 20, longitude: 10),
@@ -248,7 +248,7 @@ class AppFeatureTests: XCTestCase {
     }
     let nextRideService: NextRideService = .noop
     var settings = UserDefaultsClient.noop
-    
+
     let rideEventSettings = RideEventSettings(
       isEnabled: false,
       typeSettings: .all,
@@ -263,7 +263,7 @@ class AppFeatureTests: XCTestCase {
     locationManager.authorizationStatus = { .notDetermined }
     locationManager.locationServicesEnabled = { true }
     locationManager.requestAlwaysAuthorization = { .fireAndForget {
-        didRequestAlwaysAuthorization = true
+      didRequestAlwaysAuthorization = true
     } }
     locationManager.requestLocation = { .fireAndForget { didRequestLocation = true } }
     locationManager.set = { _ in setSubject.eraseToEffect() }
@@ -287,7 +287,7 @@ class AppFeatureTests: XCTestCase {
       rideEventSettings: rideEventSettings
     )
     environment.fileClient.load = { _ in
-        .init(value: try! JSONEncoder().encode(userSettings))
+      .init(value: try! JSONEncoder().encode(userSettings))
     }
     
     var appState = AppState(settingsState: .init(userSettings: userSettings))
@@ -357,9 +357,10 @@ class AppFeatureTests: XCTestCase {
       reducer: appReducer,
       environment: AppEnvironment(
         uiApplicationClient: .noop,
-        setUserInterfaceStyle: { _ in .none })
+        setUserInterfaceStyle: { _ in .none }
+      )
     )
-    
+
     store.send(.setNavigation(tag: .chat)) {
       $0.route = .chat
       XCTAssertTrue($0.isChatViewPresented)
@@ -382,24 +383,25 @@ class AppFeatureTests: XCTestCase {
       $0.route = .none
     }
   }
-  
+
   func test_resetUnreadMessagesCount_whenAction_chat_onAppear() {
     var appState = AppState()
     appState.chatMessageBadgeCount = 13
-    
+
     let store = TestStore(
       initialState: appState,
       reducer: appReducer,
       environment: AppEnvironment(
         uiApplicationClient: .noop,
-        setUserInterfaceStyle: { _ in .none })
+        setUserInterfaceStyle: { _ in .none }
+      )
     )
-    
+
     store.send(.social(.chat(.onAppear))) { state in
       state.chatMessageBadgeCount = 0
     }
   }
-    
+
   func test_animateNextRideBanner() {
     let store = TestStore(
       initialState: AppState(),
@@ -411,13 +413,13 @@ class AppFeatureTests: XCTestCase {
         pathMonitorClient: .satisfied
       )
     )
-    
+
     let ride = Ride(
       id: 123,
       slug: nil,
       title: "Next Ride",
       description: nil,
-      dateTime: Date(timeIntervalSince1970: 1234340120),
+      dateTime: Date(timeIntervalSince1970: 1_234_340_120),
       location: nil,
       latitude: nil,
       longitude: nil,
@@ -463,7 +465,7 @@ class AppFeatureTests: XCTestCase {
     let response2: LocationAndChatMessages = .init(
       locations: [:],
       chatMessages: [
-        "NEWID": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 15)
+        "NEWID": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 15),
       ]
     )
     let response3: LocationAndChatMessages = .init(
@@ -471,7 +473,7 @@ class AppFeatureTests: XCTestCase {
       chatMessages: [
         "NEWID": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 15),
         "NEWID3": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 16),
-        "NEWID2": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 17)
+        "NEWID2": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 17),
       ]
     )
     let response4: LocationAndChatMessages = .init(
@@ -480,7 +482,7 @@ class AppFeatureTests: XCTestCase {
         "NEWID": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 15),
         "NEWID3": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 16),
         "NEWID2": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 17),
-        "NEWID5": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 18)
+        "NEWID5": ChatMessage(message: "Hi", timestamp: date().timeIntervalSince1970 + 18),
       ]
     )
     
@@ -664,11 +666,12 @@ class AppFeatureTests: XCTestCase {
 }
 
 // MARK: Helper
+
 let testError = NSError(domain: "", code: 1, userInfo: [:])
 
 extension Coordinate {
   static func make() -> Self {
-    let randomDouble: () -> Double = { Double.random(in: 0.0...80.00) }
+    let randomDouble: () -> Double = { Double.random(in: 0.0 ... 80.00) }
     return Coordinate(latitude: randomDouble(), longitude: randomDouble())
   }
 }
@@ -677,10 +680,10 @@ let testDate: () -> Date = { Date(timeIntervalSinceReferenceDate: 0) }
 
 extension Dictionary where Key == String, Value == SharedModels.Location {
   static func make(_ max: Int = 5) -> [Key: Value] {
-    let locations = Array(0...max).map { index in
+    let locations = Array(0 ... max).map { index in
       SharedModels.Location(
         coordinate: .make(),
-        timestamp: testDate().timeIntervalSince1970 + Double((index % 2 == 0 ? index : -index))
+        timestamp: testDate().timeIntervalSince1970 + Double(index % 2 == 0 ? index : -index)
       )
     }
     var locationDict: [String: SharedModels.Location] = [:]
@@ -693,10 +696,10 @@ extension Dictionary where Key == String, Value == SharedModels.Location {
 
 extension Dictionary where Key == String, Value == ChatMessage {
   static func make(_ max: Int = 5) -> [Key: Value] {
-    let messages = Array(0...max).map { index in
+    let messages = Array(0 ... max).map { index in
       ChatMessage(
         message: "Hello World!",
-        timestamp: testDate().timeIntervalSince1970 + Double((index % 2 == 0 ? index : -index))
+        timestamp: testDate().timeIntervalSince1970 + Double(index % 2 == 0 ? index : -index)
       )
     }
     var messagesDict: [String: ChatMessage] = [:]

--- a/CriticalMapsKit/Tests/MapFeatureTests/MapFeatureCoreTests.swift
+++ b/CriticalMapsKit/Tests/MapFeatureTests/MapFeatureCoreTests.swift
@@ -20,10 +20,10 @@ class MapFeatureCoreTests: XCTestCase {
     locationManager.authorizationStatus = { .notDetermined }
     locationManager.locationServicesEnabled = { true }
     locationManager.requestAlwaysAuthorization = { .fireAndForget {
-        didRequestAlwaysAuthorization = true
+      didRequestAlwaysAuthorization = true
     } }
     locationManager.requestLocation = { .fireAndForget {
-        didRequestLocation = true
+      didRequestLocation = true
     } }
     locationManager.set = { _ in setSubject.eraseToEffect() }
       
@@ -113,7 +113,6 @@ class MapFeatureCoreTests: XCTestCase {
     }
     setSubject.send(completion: .finished)
     locationManagerSubject.send(completion: .finished)
-    
   }
   
   func test_deniedPermission_shouldSetAlert() {
@@ -126,7 +125,7 @@ class MapFeatureCoreTests: XCTestCase {
     locationManager.authorizationStatus = { .notDetermined }
     locationManager.locationServicesEnabled = { true }
     locationManager.requestAlwaysAuthorization = { .fireAndForget {
-        didRequestAlwaysAuthorization = true
+      didRequestAlwaysAuthorization = true
     } }
     locationManager.set = { _ in setSubject.eraseToEffect() }
 
@@ -169,6 +168,7 @@ class MapFeatureCoreTests: XCTestCase {
       locationManager: .failing,
       mainQueue: testScheduler.eraseToAnyScheduler()
     )
+
     let ride = Ride(
       id: 123,
       slug: "SLUG",
@@ -256,6 +256,7 @@ class MapFeatureCoreTests: XCTestCase {
     locationManager.locationServicesEnabled = { true }
     locationManager.set = { _ in setSubject.eraseToEffect() }
     
+
     let env = MapFeatureEnvironment(
       locationManager: locationManager,
       mainQueue: testScheduler.eraseToAnyScheduler()

--- a/CriticalMapsKit/Tests/NextRideFeatureTests/NextRideCoreTests.swift
+++ b/CriticalMapsKit/Tests/NextRideFeatureTests/NextRideCoreTests.swift
@@ -20,6 +20,7 @@ final class NextRideCoreTests: XCTestCase {
       )
     )!
   }
+
   let testScheduler = DispatchQueue.immediate
   
   var rides: [Ride] {
@@ -57,9 +58,10 @@ final class NextRideCoreTests: XCTestCase {
         disabledReason: nil,
         disabledReasonMessage: nil,
         rideType: .alleycat
-      )
+      ),
     ]
   }
+
   let coordinate = Coordinate(latitude: 53.1234, longitude: 13.4233)
   
   func test_disabledNextRideFeature_shouldNotRequestRides() {
@@ -161,7 +163,7 @@ final class NextRideCoreTests: XCTestCase {
       try? RideEventSettings(
         isEnabled: true,
         typeSettings: [
-          RideEventSettings.RideEventTypeSetting(type: Ride.RideType.kidicalMass, isEnabled: true)
+          RideEventSettings.RideEventTypeSetting(type: Ride.RideType.kidicalMass, isEnabled: true),
         ],
         eventDistance: .near
       )
@@ -263,7 +265,7 @@ final class NextRideCoreTests: XCTestCase {
         slug: nil,
         title: "CriticalMaps Berlin",
         description: nil,
-        dateTime: self.now().addingTimeInterval(3600),
+        dateTime: now().addingTimeInterval(3600),
         location: nil,
         latitude: 53.1235,
         longitude: 13.4234,
@@ -274,17 +276,17 @@ final class NextRideCoreTests: XCTestCase {
         disabledReason: nil,
         disabledReasonMessage: nil,
         rideType: .criticalMass
-      )
+      ),
     ]
     let service = NextRideService(nextRide: { _, _, _ in
       Just(rides)
-      .setFailureType(to: NextRideService.Failure.self)
-      .eraseToAnyPublisher()
+        .setFailureType(to: NextRideService.Failure.self)
+        .eraseToAnyPublisher()
     })
     var settings: UserDefaultsClient = .noop
     settings.dataForKey = { _ in
       try? RideEventSettings.default
-      .encoded()
+        .encoded()
     }
     // when
     let store = TestStore(
@@ -301,6 +303,7 @@ final class NextRideCoreTests: XCTestCase {
     // then
     store.send(.getNextRide(coordinate))
     store.receive(.nextRideResponse(.success(rides))) {
+      $0.rideEvents = rides
       $0.nextRide = nil
     }
   }
@@ -324,7 +327,7 @@ final class NextRideCoreTests: XCTestCase {
         slug: nil,
         title: "CriticalMaps Berlin",
         description: nil,
-        dateTime: self.now().addingTimeInterval(3600),
+        dateTime: now().addingTimeInterval(3600),
         location: nil,
         latitude: 53.1235,
         longitude: 13.4234,
@@ -352,12 +355,12 @@ final class NextRideCoreTests: XCTestCase {
         disabledReason: nil,
         disabledReasonMessage: nil,
         rideType: .criticalMass
-      )
+      ),
     ]
     let service = NextRideService(nextRide: { _, _, _ in
       Just(rides)
-      .setFailureType(to: NextRideService.Failure.self)
-      .eraseToAnyPublisher()
+        .setFailureType(to: NextRideService.Failure.self)
+        .eraseToAnyPublisher()
     })
     var settings: UserDefaultsClient = .noop
     settings.dataForKey = { _ in
@@ -393,7 +396,7 @@ final class NextRideCoreTests: XCTestCase {
         slug: nil,
         title: "CriticalMaps Berlin",
         description: nil,
-        dateTime: self.now().addingTimeInterval(60 * 60 * 24).addingTimeInterval(3600),
+        dateTime: now().addingTimeInterval(60 * 60 * 24).addingTimeInterval(3600),
         location: nil,
         latitude: 53.1235,
         longitude: 13.4234,
@@ -421,12 +424,12 @@ final class NextRideCoreTests: XCTestCase {
         disabledReason: nil,
         disabledReasonMessage: nil,
         rideType: .criticalMass
-      )
+      ),
     ]
     let service = NextRideService(nextRide: { _, _, _ in
       Just(rides)
-      .setFailureType(to: NextRideService.Failure.self)
-      .eraseToAnyPublisher()
+        .setFailureType(to: NextRideService.Failure.self)
+        .eraseToAnyPublisher()
     })
     var settings: UserDefaultsClient = .noop
     settings.dataForKey = { _ in
@@ -462,7 +465,7 @@ final class NextRideCoreTests: XCTestCase {
         slug: nil,
         title: "CriticalMaps Berlin",
         description: nil,
-        dateTime: self.now().addingTimeInterval(60 * 60 * 48).addingTimeInterval(3600),
+        dateTime: now().addingTimeInterval(60 * 60 * 48).addingTimeInterval(3600),
         location: nil,
         latitude: 53.1235,
         longitude: 13.4234,
@@ -490,12 +493,12 @@ final class NextRideCoreTests: XCTestCase {
         disabledReason: nil,
         disabledReasonMessage: nil,
         rideType: .criticalMass
-      )
+      ),
     ]
     let service = NextRideService(nextRide: { _, _, _ in
       Just(rides)
-      .setFailureType(to: NextRideService.Failure.self)
-      .eraseToAnyPublisher()
+        .setFailureType(to: NextRideService.Failure.self)
+        .eraseToAnyPublisher()
     })
     var settings: UserDefaultsClient = .noop
     settings.dataForKey = { _ in
@@ -531,7 +534,7 @@ final class NextRideCoreTests: XCTestCase {
         slug: nil,
         title: "CriticalMaps Berlin",
         description: nil,
-        dateTime: self.now().addingTimeInterval(60 * 60 * 48).addingTimeInterval(3600),
+        dateTime: now().addingTimeInterval(60 * 60 * 48).addingTimeInterval(3600),
         location: nil,
         latitude: 53.1235,
         longitude: 13.4234,
@@ -559,12 +562,12 @@ final class NextRideCoreTests: XCTestCase {
         disabledReason: nil,
         disabledReasonMessage: nil,
         rideType: .criticalMass
-      )
+      ),
     ]
     let service = NextRideService(nextRide: { _, _, _ in
       Just(rides)
-      .setFailureType(to: NextRideService.Failure.self)
-      .eraseToAnyPublisher()
+        .setFailureType(to: NextRideService.Failure.self)
+        .eraseToAnyPublisher()
     })
     var settings: UserDefaultsClient = .noop
     settings.dataForKey = { _ in

--- a/CriticalMapsKit/Tests/NextRideFeatureTests/NextRideCoreTests.swift
+++ b/CriticalMapsKit/Tests/NextRideFeatureTests/NextRideCoreTests.swift
@@ -111,7 +111,9 @@ final class NextRideCoreTests: XCTestCase {
     )
     // then
     store.send(.getNextRide(coordinate))
-    store.receive(.nextRideResponse(.success(rides)))
+    store.receive(.nextRideResponse(.success(rides))) {
+      $0.rideEvents = self.rides.sortByDateAndFilterBeforeDate(store.environment.now)
+    }
     store.receive(.setNextRide(rides[1])) {
       $0.nextRide = self.rides[1]
     }
@@ -179,48 +181,50 @@ final class NextRideCoreTests: XCTestCase {
     )
     // then
     store.send(.getNextRide(coordinate))
-    store.receive(.nextRideResponse(.success(rides)))
+    store.receive(.nextRideResponse(.success(rides))) {
+      $0.rideEvents = self.rides.sortByDateAndFilterBeforeDate(store.environment.now)
+    }
   }
-  
+
   func test_getNextRide_shouldReturnRide_whenRideTypeNil() {
     var ridesWithARideWithNilRideType: [Ride] {
-        [
-          Ride(
-            id: 0,
-            slug: nil,
-            title: "CriticalMaps Berlin",
-            description: nil,
-            dateTime: now().addingTimeInterval(36000),
-            location: nil,
-            latitude: 53.1235,
-            longitude: 13.4234,
-            estimatedParticipants: nil,
-            estimatedDistance: nil,
-            estimatedDuration: nil,
-            enabled: true,
-            disabledReason: nil,
-            disabledReasonMessage: nil,
-            rideType: .criticalMass
-          ),
-          Ride(
-            id: 0,
-            slug: nil,
-            title: "CriticalMaps Falkensee",
-            description: nil,
-            dateTime: now().addingTimeInterval(3600),
-            location: "Vorplatz der alten Stadthalle",
-            latitude: 53.1235,
-            longitude: 13.4234,
-            estimatedParticipants: nil,
-            estimatedDistance: nil,
-            estimatedDuration: nil,
-            enabled: true,
-            disabledReason: nil,
-            disabledReasonMessage: nil,
-            rideType: nil
-          )
-        ]
-      }
+      [
+        Ride(
+          id: 0,
+          slug: nil,
+          title: "CriticalMaps Berlin",
+          description: nil,
+          dateTime: now().addingTimeInterval(36000),
+          location: nil,
+          latitude: 53.1235,
+          longitude: 13.4234,
+          estimatedParticipants: nil,
+          estimatedDistance: nil,
+          estimatedDuration: nil,
+          enabled: true,
+          disabledReason: nil,
+          disabledReasonMessage: nil,
+          rideType: .criticalMass
+        ),
+        Ride(
+          id: 0,
+          slug: nil,
+          title: "CriticalMaps Falkensee",
+          description: nil,
+          dateTime: now().addingTimeInterval(3600),
+          location: "Vorplatz der alten Stadthalle",
+          latitude: 53.1235,
+          longitude: 13.4234,
+          estimatedParticipants: nil,
+          estimatedDistance: nil,
+          estimatedDuration: nil,
+          enabled: true,
+          disabledReason: nil,
+          disabledReasonMessage: nil,
+          rideType: nil
+        ),
+      ]
+    }
     let service = NextRideService(nextRide: { _, _, _ in
       Just(ridesWithARideWithNilRideType)
         .setFailureType(to: NextRideService.Failure.self)
@@ -244,7 +248,9 @@ final class NextRideCoreTests: XCTestCase {
     )
     // then
     store.send(.getNextRide(coordinate))
-    store.receive(.nextRideResponse(.success(ridesWithARideWithNilRideType)))
+    store.receive(.nextRideResponse(.success(ridesWithARideWithNilRideType))) {
+      $0.rideEvents = ridesWithARideWithNilRideType.sortByDateAndFilterBeforeDate(store.environment.now)
+    }
     store.receive(.setNextRide(ridesWithARideWithNilRideType[1])) {
       $0.nextRide = ridesWithARideWithNilRideType[1]
     }
@@ -372,7 +378,9 @@ final class NextRideCoreTests: XCTestCase {
     )
     // then
     store.send(.getNextRide(coordinate))
-    store.receive(.nextRideResponse(.success(rides)))
+    store.receive(.nextRideResponse(.success(rides))) {
+      $0.rideEvents = rides.sortByDateAndFilterBeforeDate(store.environment.now)
+    }
     store.receive(.setNextRide(rides[0])) {
       $0.nextRide = rides[0]
     }
@@ -439,12 +447,14 @@ final class NextRideCoreTests: XCTestCase {
     )
     // then
     store.send(.getNextRide(coordinate))
-    store.receive(.nextRideResponse(.success(rides)))
+    store.receive(.nextRideResponse(.success(rides))) {
+      $0.rideEvents = rides.sortByDateAndFilterBeforeDate(store.environment.now)
+    }
     store.receive(.setNextRide(rides[0])) {
       $0.nextRide = rides[0]
     }
   }
-  
+
   func test_getNextRide_returnRideFromThisMonth_whenTodayIsSunday() {
     let rides = [
       Ride(
@@ -506,7 +516,9 @@ final class NextRideCoreTests: XCTestCase {
     )
     // then
     store.send(.getNextRide(coordinate))
-    store.receive(.nextRideResponse(.success(rides)))
+    store.receive(.nextRideResponse(.success(rides))) {
+      $0.rideEvents = rides.sortByDateAndFilterBeforeDate(store.environment.now)
+    }
     store.receive(.setNextRide(rides[0])) {
       $0.nextRide = rides[0]
     }
@@ -573,7 +585,9 @@ final class NextRideCoreTests: XCTestCase {
     )
     // then
     store.send(.getNextRide(coordinate))
-    store.receive(.nextRideResponse(.success(rides)))
+    store.receive(.nextRideResponse(.success(rides))) {
+      $0.rideEvents = rides.sortByDateAndFilterBeforeDate(store.environment.now)
+    }
     store.receive(.setNextRide(rides[1])) {
       $0.nextRide = rides[1]
     }


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

A user can now view all upcoming events from a list. The events will also be visible on the map. 

## 🤔 Why

Some users requested the feature and I also thought about it but didn't found the time.

## 👀 See

<img width="454" alt="Screenshot 2022-05-15 at 10 04 45" src="https://user-images.githubusercontent.com/14075359/168470462-b6de1d96-d6f8-40d9-a588-9b99c551182a.png">
<img width="454" alt="Screenshot 2022-05-16 at 08 08 04" src="https://user-images.githubusercontent.com/14075359/168529634-b88ff200-d57e-424d-b5f5-d265a6d4d843.png">


## ♿️ Accessibility 

- [ ] Tap targets use minimum of 44x44 pts dimensions
- [x] Works with VoiceOver
- [x] Supports Dynamic Type 
