### PR TITLE
Replace a deprecated property wrapper

### DIFF
--- a/CriticalMapsKit/Sources/ChatFeature/ChatInputCore.swift
+++ b/CriticalMapsKit/Sources/ChatFeature/ChatInputCore.swift
@@ -8,7 +8,7 @@ public struct ChatInput: ReducerProtocol {
   // MARK: State
 
   public struct State: Equatable {
-    @BindableState
+    @BindingState
     public var isEditing = false
     public var message = ""
     public var isSending = false

--- a/CriticalMapsKit/Sources/SharedModels/AppearanceSettings.swift
+++ b/CriticalMapsKit/Sources/SharedModels/AppearanceSettings.swift
@@ -4,8 +4,8 @@ import enum UIKit.UIUserInterfaceStyle
 
 /// A structure that represents a users appearance settings.
 public struct AppearanceSettings: Codable, Equatable {
-  @BindableState public var appIcon: AppIcon
-  @BindableState public var colorScheme: ColorScheme
+  @BindingState public var appIcon: AppIcon
+  @BindingState public var colorScheme: ColorScheme
 
   public init(appIcon: AppIcon = .appIcon2, colorScheme: ColorScheme = .system) {
     self.appIcon = appIcon


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📲 What

This PR replaces `@BindableState` with `@BindingState`.

## 🤔 Why

`@BindableState` is deprecated in the current TCA.

## 👀 See

- https://github.com/pointfreeco/swift-composable-architecture/blob/bb384617d992b54f749af76b21c79e1bd6004e5a/Sources/ComposableArchitecture/Documentation.docc/Extensions/Deprecations/SwiftUIDeprecations.md#bindablestate