### PR TITLE
Fix testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,7 @@ PLATFORMS
   arm64-darwin-20
   universal-darwin-21
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   fastlane


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📲 What

This PR runs `bundle lock --add-platform x86_64-darwin-20` and tries to fix testing.

## 🤔 Why

A failed log says:

```
Your bundle only supports platforms ["arm64-darwin-20", "universal-darwin-21",
"x86_64-darwin-19"] but your local platform is x86_64-darwin-20. Add the current
platform to the lockfile with `bundle lock --add-platform x86_64-darwin-20` and
try again.
```
https://github.com/criticalmaps/criticalmaps-ios/actions/runs/4791748214/jobs/8526593053?pr=469