### PR TITLE
Set lower frequency for getting data from server

### DIFF
--- a/CriticalMapsKit/Sources/AppFeature/RequestTimerCore.swift
+++ b/CriticalMapsKit/Sources/AppFeature/RequestTimerCore.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import Foundation
 
 public struct RequestTimer: ReducerProtocol {
-  public init(timerInterval: Int = 15) {
+  public init(timerInterval: Int = 60) {
     self.timerInterval = .seconds(timerInterval)
   }
 


### PR DESCRIPTION
I set the `/locations`-cache TTL to 60 seconds so pulling more often doesn't really give any benefit anymore.
Not sure if this effects the frequency of pulling messages as well. If it does, please only pull that endpoint when the view is open (through a refresh button for example and at an interval that is paused once view is closed).