### PR TITLE
Fix for `coordinate` encoding

### DIFF
--- a/CriticalMapsKit/Sources/ApiClient/Requests/SendLocationPostBody.swift
+++ b/CriticalMapsKit/Sources/ApiClient/Requests/SendLocationPostBody.swift
@@ -22,7 +22,15 @@ public struct SendLocationPostBody: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(self.device, forKey: .device)
-    try container.encodeIfPresent(self.location?.coordinate.latitude, forKey: .latitude)
-    try container.encodeIfPresent(self.location?.coordinate.longitude, forKey: .longitude)
+    if let location {
+      try container.encodeIfPresent(
+        location.coordinate.latitude * 1_000_000,
+        forKey: .latitude
+      )
+      try container.encodeIfPresent(
+        location.coordinate.longitude * 1_000_000,
+        forKey: .longitude
+      )
+    }
   }
 }

--- a/CriticalMapsKit/Sources/SharedModels/Location.swift
+++ b/CriticalMapsKit/Sources/SharedModels/Location.swift
@@ -39,8 +39,8 @@ extension Location: Codable {
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    let latitude = try container.decode(Double.self, forKey: .latitude) / 1000000
-    let longitude = try container.decode(Double.self, forKey: .longitude) / 1000000
+    let latitude = try container.decode(Double.self, forKey: .latitude) / 1_000_000
+    let longitude = try container.decode(Double.self, forKey: .longitude) / 1_000_000
     coordinate = Coordinate(latitude: latitude, longitude: longitude)
     try timestamp = container.decode(Double.self, forKey: .timestamp)
     try name = container.decodeIfPresent(String.self, forKey: .name)
@@ -49,8 +49,8 @@ extension Location: Codable {
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(coordinate.longitude * 1000000, forKey: .longitude)
-    try container.encode(coordinate.latitude * 1000000, forKey: .latitude)
+    try container.encode(coordinate.longitude * 1_000_000, forKey: .longitude)
+    try container.encode(coordinate.latitude * 1_000_000, forKey: .latitude)
     try container.encode(timestamp, forKey: .timestamp)
     try container.encodeIfPresent(color, forKey: .color)
     try container.encodeIfPresent(name, forKey: .name)


### PR DESCRIPTION
Backend expects `latitude` and `longitude` to be formatted