### PR TITLE
Fix ride event settings update should fetch events again

### DIFF
--- a/CriticalMapsKit/Sources/ApiClient/Requests/SendLocationPostBody.swift
+++ b/CriticalMapsKit/Sources/ApiClient/Requests/SendLocationPostBody.swift
@@ -22,7 +22,15 @@ public struct SendLocationPostBody: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(self.device, forKey: .device)
-    try container.encodeIfPresent(self.location?.coordinate.latitude, forKey: .latitude)
-    try container.encodeIfPresent(self.location?.coordinate.longitude, forKey: .longitude)
+    if let location {
+      try container.encodeIfPresent(
+        location.coordinate.latitude * 1_000_000,
+        forKey: .latitude
+      )
+      try container.encodeIfPresent(
+        location.coordinate.longitude * 1_000_000,
+        forKey: .longitude
+      )
+    }
   }
 }

--- a/CriticalMapsKit/Sources/AppFeature/AppFeatureCore.swift
+++ b/CriticalMapsKit/Sources/AppFeature/AppFeatureCore.swift
@@ -279,7 +279,7 @@ public struct AppFeature: ReducerProtocol {
         return .none
         
       case .postLocation:
-        guard state.settingsState.userSettings.enableObservationMode else {
+        guard !state.settingsState.userSettings.enableObservationMode else {
           return .none
         }
         

--- a/CriticalMapsKit/Sources/MapFeature/MapFeatureCore.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapFeatureCore.swift
@@ -272,7 +272,7 @@ extension LocationManager {
         activityType: .otherNavigation,
         allowsBackgroundLocationUpdates: true,
         desiredAccuracy: kCLLocationAccuracyBest,
-        distanceFilter: 42.0,
+        distanceFilter: 100.0,
         headingFilter: nil,
         pausesLocationUpdatesAutomatically: false,
         showsBackgroundLocationIndicator: true

--- a/CriticalMapsKit/Sources/SharedModels/Location.swift
+++ b/CriticalMapsKit/Sources/SharedModels/Location.swift
@@ -39,8 +39,8 @@ extension Location: Codable {
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
-    let latitude = try container.decode(Double.self, forKey: .latitude) / 1000000
-    let longitude = try container.decode(Double.self, forKey: .longitude) / 1000000
+    let latitude = try container.decode(Double.self, forKey: .latitude) / 1_000_000
+    let longitude = try container.decode(Double.self, forKey: .longitude) / 1_000_000
     coordinate = Coordinate(latitude: latitude, longitude: longitude)
     try timestamp = container.decode(Double.self, forKey: .timestamp)
     try name = container.decodeIfPresent(String.self, forKey: .name)
@@ -49,8 +49,8 @@ extension Location: Codable {
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    try container.encode(coordinate.longitude * 1000000, forKey: .longitude)
-    try container.encode(coordinate.latitude * 1000000, forKey: .latitude)
+    try container.encode(coordinate.longitude * 1_000_000, forKey: .longitude)
+    try container.encode(coordinate.latitude * 1_000_000, forKey: .latitude)
     try container.encode(timestamp, forKey: .timestamp)
     try container.encodeIfPresent(color, forKey: .color)
     try container.encodeIfPresent(name, forKey: .name)

--- a/CriticalMapsKit/Sources/SharedModels/NextRideFeature/RideEventSettings.swift
+++ b/CriticalMapsKit/Sources/SharedModels/NextRideFeature/RideEventSettings.swift
@@ -3,9 +3,9 @@ import Foundation
 /// A structure to store ride event settings
 public struct RideEventSettings: Hashable, Codable {
   public init(
-    isEnabled: Bool,
-    typeSettings: [RideEventSettings.RideEventTypeSetting],
-    eventDistance: EventDistance
+    isEnabled: Bool = true,
+    typeSettings: [RideEventSettings.RideEventTypeSetting] = .all,
+    eventDistance: EventDistance = .near
   ) {
     self.isEnabled = isEnabled
     self.typeSettings = typeSettings

--- a/CriticalMapsKit/Sources/TwitterFeedFeature/TweetView.swift
+++ b/CriticalMapsKit/Sources/TwitterFeedFeature/TweetView.swift
@@ -3,6 +3,7 @@ import Foundation
 import SharedModels
 import Styleguide
 import SwiftUI
+import UIApplicationClient
 
 public struct TweetFeature: ReducerProtocol {
   public init() {}

--- a/CriticalMapsKit/Sources/TwitterFeedFeature/TwitterFeedFeatureCore.swift
+++ b/CriticalMapsKit/Sources/TwitterFeedFeature/TwitterFeedFeatureCore.swift
@@ -7,6 +7,7 @@ import SharedDependencies
 import SharedModels
 import Styleguide
 import SwiftUI
+import UIApplicationClient
 
 public struct TwitterFeedFeature: ReducerProtocol {
   public init() {}

--- a/CriticalMapsKit/Sources/UserDefaultsClient/Interface.swift
+++ b/CriticalMapsKit/Sources/UserDefaultsClient/Interface.swift
@@ -15,19 +15,6 @@ public struct UserDefaultsClient {
   public var setDouble: @Sendable (Double, String) async -> Void
   public var setInteger: @Sendable (Int, String) async -> Void
 
-  /// Convenience getter for rideEvents
-  public var rideEventSettings: RideEventSettings {
-    guard let data = dataForKey(rideEventSettingsKey) else {
-      return .default
-    }
-    return (try? data.decoded()) ?? .default
-  }
-
-  /// Convenience setter for rideEvents
-  public func setRideEventSettings(_ settings: RideEventSettings) async {
-    await setData(try? settings.encoded(), rideEventSettingsKey)
-  }
-
   /// Convenience getter for chat read timeinterval
   public var chatReadTimeInterval: Double {
     doubleForKey(chatReadTimeIntervalKey)


### PR DESCRIPTION
## 📝 Docs

- [ ] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

Any update to rideEvent settings should trigger a refetch of the `nextRide` call

## 🤔 Why

ATM only the update to `enabled` triggered that call.
The PR will also remove a redundant settings that was stored to `UserDefaults`