### PR TITLE
increase distance filter location update

### DIFF
--- a/CriticalMapsKit/Sources/MapFeature/MapFeatureCore.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapFeatureCore.swift
@@ -272,7 +272,7 @@ extension LocationManager {
         activityType: .otherNavigation,
         allowsBackgroundLocationUpdates: true,
         desiredAccuracy: kCLLocationAccuracyBest,
-        distanceFilter: 42.0,
+        distanceFilter: 200.0,
         headingFilter: nil,
         pausesLocationUpdatesAutomatically: false,
         showsBackgroundLocationIndicator: true


### PR DESCRIPTION
## 📲 What

Update Location Features `distanceFilter` to only publish a new location if users have moved 200 metres

## 🤔 Why

To reduce sending locations too often.
For a ride of 20km it means: 
20.000 / 200 = 100 updates for a user per ride

There is some uncertainty around gps position since it might jump a bit where there maybe a timer would be the better option. 