### PR TITLE
Return `elements` for `ContentState.loading` to prevent blinking

### DIFF
--- a/CriticalMapsKit/Sources/Helpers/ContentState.swift
+++ b/CriticalMapsKit/Sources/Helpers/ContentState.swift
@@ -10,7 +10,7 @@ public enum ContentState<T: Hashable>: Equatable {
 
   public var elements: T? {
     switch self {
-    case let .results(results):
+    case let .results(results), let .loading(results):
       return results
     default:
       return nil

--- a/CriticalMapsKit/Tests/ChatFeatureTests/ChatFeatureCoreTests.swift
+++ b/CriticalMapsKit/Tests/ChatFeatureTests/ChatFeatureCoreTests.swift
@@ -1,8 +1,8 @@
 import ApiClient
 import ChatFeature
 import ComposableArchitecture
-import L10n
 import Helpers
+import L10n
 import SharedModels
 import UserDefaultsClient
 import XCTest


### PR DESCRIPTION
<!-- This template is **just a guide**, delete any and all parts which you don't need! -->

## 📲 What

- return elements on `ContentState` also for `loading` case

## 🤔 Why

The chat view was blinking for a short while when loading items and showing the `emptystate`.