### PR TITLE
Add `AppIntent` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Critical Maps iOS
 - PrivacyZones Feature:
   - Create and manage zones where your location won't be shared with other riders
 - You can now browse image attachments of Mastodon posts
+- Adds an AppIntent so you can toggle the ObservationMode from Shortcuts and Siri
   
 ### Updated
 

--- a/CriticalMaps.xcodeproj/project.pbxproj
+++ b/CriticalMaps.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		739A582D2D41290F00B80B41 /* ChatFeaturePreviewApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739A58262D41290F00B80B41 /* ChatFeaturePreviewApp.swift */; };
 		739A582E2D41290F00B80B41 /* SettingsFeaturePreviewApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739A582A2D41290F00B80B41 /* SettingsFeaturePreviewApp.swift */; };
 		739A582F2D41290F00B80B41 /* GuideFeaturePreviewApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739A58282D41290F00B80B41 /* GuideFeaturePreviewApp.swift */; };
+		73C137152E7D59F100E949D9 /* AppIntentFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 73C137142E7D59F100E949D9 /* AppIntentFeature */; };
 		73CA22FA2D4158650040C7CF /* GuideFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 73CA22F92D4158650040C7CF /* GuideFeature */; };
 		73CF5FF7263EB0A6001925A3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 73CF5FF1263EB0A6001925A3 /* Assets.xcassets */; };
 		73EB0311263F23A100941D57 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73EB0310263F23A100941D57 /* App.swift */; };
@@ -81,6 +82,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				731CFCC9267A745600F1093B /* AppFeature in Frameworks */,
+				73C137152E7D59F100E949D9 /* AppIntentFeature in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -256,6 +258,7 @@
 			name = "Critical Maps";
 			packageProductDependencies = (
 				731CFCC8267A745600F1093B /* AppFeature */,
+				73C137142E7D59F100E949D9 /* AppIntentFeature */,
 			);
 			productName = "Critical Maps";
 			productReference = 739A58302D414F4B00B80B41 /* Critical Maps.app */;
@@ -842,6 +845,10 @@
 		73238EDC277328E8003DE01F /* SettingsFeature */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SettingsFeature;
+		};
+		73C137142E7D59F100E949D9 /* AppIntentFeature */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AppIntentFeature;
 		};
 		73CA22F92D4158650040C7CF /* GuideFeature */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/CriticalMapsKit/Package.swift
+++ b/CriticalMapsKit/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
   products: [
     .singleTargetLibrary("ApiClient"),
     .singleTargetLibrary("AppFeature"),
+    .singleTargetLibrary("AppIntentFeature"),
     .singleTargetLibrary("ChatFeature"),
     .singleTargetLibrary("GuideFeature"),
     .singleTargetLibrary("MapFeature"),
@@ -66,6 +67,13 @@ let package = Package(
         .styleguide,
         .userDefaultsClient,
         .uiApplicationClient,
+        .tca
+      ]
+    ),
+    .target(
+      name: "AppIntentFeature",
+      dependencies: [
+        .sharedModels,
         .tca
       ]
     ),

--- a/CriticalMapsKit/Sources/AppFeature/AppFeature.swift
+++ b/CriticalMapsKit/Sources/AppFeature/AppFeature.swift
@@ -148,7 +148,7 @@ public struct AppFeature {
   @Dependency(\.feedbackGenerator) var feedbackGenerator
   @Dependency(\.uiApplicationClient) var uiApplicationClient
 
-  public var body: some Reducer<State, Action> {
+  public var body: some ReducerOf<Self> {
     BindingReducer()
     
     Scope(state: \.requestTimer, action: \.requestTimer) {
@@ -472,20 +472,22 @@ public struct AppFeature {
         }
         return .merge(effects)
         
-      case .binding(\.isEventListPresented):
-        if !state.isEventListPresented {
+      case .binding:
+        return .none
+      }
+    }
+    .ifLet(\.$destination, action: \.destination)
+    .onChange(of: \.isEventListPresented) { _, newValue in
+      Reduce { state, action in
+        if !newValue {
           state.mapFeatureState.rideEvents = []
           state.mapFeatureState.eventCenter = nil
         } else {
           state.mapFeatureState.rideEvents = state.nextRideState.rideEvents
         }
         return .none
-        
-      case .binding:
-        return .none
       }
     }
-    .ifLet(\.$destination, action: \.destination)
   }
 }
 

--- a/CriticalMapsKit/Sources/AppFeature/AppFeature.swift
+++ b/CriticalMapsKit/Sources/AppFeature/AppFeature.swift
@@ -127,6 +127,7 @@ public struct AppFeature {
     case socialButtonTapped
     case settingsButtonTapped
     case didTapNextRideOverlayButton
+    case dismissEventList
     case dismissDestination
     
     case map(MapFeatureAction)
@@ -471,6 +472,10 @@ public struct AppFeature {
           effects.append(.send(.map(.focusNextRide(state.nextRideState.nextRide?.coordinate))))
         }
         return .merge(effects)
+      
+      case .dismissEventList:
+        state.isEventListPresented = false
+        return .none
         
       case .binding:
         return .none

--- a/CriticalMapsKit/Sources/AppFeature/AppView.swift
+++ b/CriticalMapsKit/Sources/AppFeature/AppView.swift
@@ -46,8 +46,7 @@ public struct AppView: View {
     }
     .sheet(
       isPresented: $store.isEventListPresented,
-      onDismiss: { store.send(.set(\.isEventListPresented, false))
-      },
+      onDismiss: { store.send(.dismissEventList) },
       content: {
         NavigationStack {
           bottomSheetContentView()

--- a/CriticalMapsKit/Sources/AppFeature/RideEventView.swift
+++ b/CriticalMapsKit/Sources/AppFeature/RideEventView.swift
@@ -1,7 +1,9 @@
 import Foundation
+import L10n
 import SharedModels
 import Styleguide
 import SwiftUI
+import UIKit
 
 struct RideEventView: View {
   let ride: Ride
@@ -28,6 +30,16 @@ struct RideEventView: View {
           
           if let location = ride.location {
             Label(location, systemImage: "mappin.and.ellipse")
+              .contextMenu {
+                if let coordinate = ride.coordinate {
+                  Button(L10n.RideEvent.ContextMenu.copyCoordinates, systemImage: "doc.on.doc") {
+                    UIPasteboard.general.string = coordinate.formattedForCopying
+                  }
+                }
+                Button(L10n.RideEvent.ContextMenu.copyLocationName, systemImage: "location") {
+                  UIPasteboard.general.string = location
+                }
+              }
           }
         }
         .font(.bodyTwo)

--- a/CriticalMapsKit/Sources/AppIntentFeature/CriticalMapsShortcuts.swift
+++ b/CriticalMapsKit/Sources/AppIntentFeature/CriticalMapsShortcuts.swift
@@ -1,0 +1,21 @@
+import AppIntents
+
+public struct CriticalMapsShortcuts: AppShortcutsProvider {
+  public static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: ObservationModeIntent(),
+      phrases: [
+        "Enable observation mode in \(.applicationName)",
+        "Turn on observation mode in \(.applicationName)",
+        "Disable observation mode in \(.applicationName)",
+        "Turn off observation mode in \(.applicationName)",
+        "Toggle observation mode in \(.applicationName)"
+      ],
+      shortTitle: LocalizedStringResource(
+        "appIntent.observationMode.shortcut.title",
+        defaultValue: "Observation Mode"
+      ),
+      systemImageName: "eye"
+    )
+  }
+}

--- a/CriticalMapsKit/Sources/AppIntentFeature/Localizable.xcstrings
+++ b/CriticalMapsKit/Sources/AppIntentFeature/Localizable.xcstrings
@@ -1,0 +1,419 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "appIntent.observationMode.description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beobachtungsmodus in CriticalMaps aktivieren oder deaktivieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable or disable observation mode in CriticalMaps"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar o desactivar el modo de observación en CriticalMaps"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar o desactivar el modo de observación en CriticalMaps"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivare o disattivare la modalità osservazione in CriticalMaps"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Włącz lub wyłącz tryb obserwacji w CriticalMaps"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativar ou desativar o modo de observação no CriticalMaps"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativar ou desativar o modo de observação no CriticalMaps"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CriticalMaps'te gözlem modunu etkinleştir veya devre dışı bırak"
+          }
+        }
+      }
+    },
+    "appIntent.observationMode.parameter.description" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ob der Beobachtungsmodus aktiviert oder deaktiviert werden soll"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Whether to enable or disable observation mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si activar o desactivar el modo de observación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si activar o desactivar el modo de observación"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se attivare o disattivare la modalità osservazione"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Czy włączyć lub wyłączyć tryb obserwacji"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se deve ativar ou desativar o modo de observação"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se deve ativar ou desativar o modo de observação"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gözlem modunun etkinleştirilip devre dışı bırakılacağı"
+          }
+        }
+      }
+    },
+    "appIntent.observationMode.parameter.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beobachtungsmodus aktivieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Enable Observation Mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar modo de observación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer le mode observation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attiva modalità osservazione"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Włącz tryb obserwacji"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativar modo de observação"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativar modo de observação"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gözlem modunu etkinleştir"
+          }
+        }
+      }
+    },
+    "appIntent.observationMode.result.disabled" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beobachtungsmodus deaktiviert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Observation mode disabled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de observación desactivado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode observation désactivé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalità osservazione disattivata"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryb obserwacji wyłączony"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de observação desativado"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de observação desativado"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gözlem modu devre dışı bırakıldı"
+          }
+        }
+      }
+    },
+    "appIntent.observationMode.result.enabled" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beobachtungsmodus aktiviert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Observation mode enabled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de observación activado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode observation activé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalità osservazione attivata"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryb obserwacji włączony"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de observação ativado"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de observação ativado"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gözlem modu etkinleştirildi"
+          }
+        }
+      }
+    },
+    "appIntent.observationMode.shortcut.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beobachtungsmodus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Observation Mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de observación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode observation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalità osservazione"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryb obserwacji"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de observação"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de observação"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gözlem modu"
+          }
+        }
+      }
+    },
+    "appIntent.observationMode.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beobachtungsmodus umschalten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toggle Observation Mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar modo de observación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basculer le mode observation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attiva modalità osservazione"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przełącz tryb obserwacji"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar modo de observação"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar modo de observação"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gözlem modunu değiştir"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.1"
+}

--- a/CriticalMapsKit/Sources/AppIntentFeature/ObservationModeIntent.swift
+++ b/CriticalMapsKit/Sources/AppIntentFeature/ObservationModeIntent.swift
@@ -1,0 +1,47 @@
+import AppIntents
+import Foundation
+import SharedModels
+import Sharing
+
+public struct ObservationModeIntent: AppIntent {
+  public static var title = LocalizedStringResource(
+    "appIntent.observationMode.title",
+    defaultValue: "Toggle Observation Mode"
+  )
+  public static var description = IntentDescription(
+    LocalizedStringResource(
+      "appIntent.observationMode.description",
+      defaultValue: "Enable or disable observation mode in CriticalMaps"
+    )
+  )
+
+  @Parameter(
+    title: LocalizedStringResource(
+      "appIntent.observationMode.parameter.title",
+      defaultValue: "Enable Observation Mode"
+    ),
+    description: LocalizedStringResource(
+      "appIntent.observationMode.parameter.description",
+      defaultValue: "Whether to enable or disable observation mode"
+    )
+  )
+  public var enableObservationMode: Bool
+
+  public init() {}
+
+  public init(enableObservationMode: Bool) {
+    self.enableObservationMode = enableObservationMode
+  }
+
+  public func perform() async throws -> some IntentResult & ProvidesDialog {
+    // Update the user settings
+    @Shared(.userSettings) var userSettings
+    $userSettings.withLock { $0.isObservationModeEnabled = enableObservationMode }
+
+    let statusMessage = userSettings.isObservationModeEnabled
+      ? String(localized: "appIntent.observationMode.result.enabled", defaultValue: "Observation mode enabled")
+      : String(localized: "appIntent.observationMode.result.disabled", defaultValue: "Observation mode disabled")
+
+    return .result(dialog: IntentDialog(stringLiteral: statusMessage))
+  }
+}

--- a/CriticalMapsKit/Sources/AppIntentFeature/ObservationModeIntent.swift
+++ b/CriticalMapsKit/Sources/AppIntentFeature/ObservationModeIntent.swift
@@ -6,23 +6,27 @@ import Sharing
 public struct ObservationModeIntent: AppIntent {
   public static var title = LocalizedStringResource(
     "appIntent.observationMode.title",
-    defaultValue: "Toggle Observation Mode"
+    defaultValue: "Toggle Observation Mode",
+    bundle: .module
   )
   public static var description = IntentDescription(
     LocalizedStringResource(
       "appIntent.observationMode.description",
-      defaultValue: "Enable or disable observation mode in CriticalMaps"
+      defaultValue: "Enable or disable observation mode in CriticalMaps",
+      bundle: .module
     )
   )
 
   @Parameter(
     title: LocalizedStringResource(
       "appIntent.observationMode.parameter.title",
-      defaultValue: "Enable Observation Mode"
+      defaultValue: "Enable Observation Mode",
+      bundle: .module
     ),
     description: LocalizedStringResource(
       "appIntent.observationMode.parameter.description",
-      defaultValue: "Whether to enable or disable observation mode"
+      defaultValue: "Whether to enable or disable observation mode",
+      bundle: .module
     )
   )
   public var enableObservationMode: Bool
@@ -39,8 +43,16 @@ public struct ObservationModeIntent: AppIntent {
     $userSettings.withLock { $0.isObservationModeEnabled = enableObservationMode }
 
     let statusMessage = userSettings.isObservationModeEnabled
-      ? String(localized: "appIntent.observationMode.result.enabled", defaultValue: "Observation mode enabled")
-      : String(localized: "appIntent.observationMode.result.disabled", defaultValue: "Observation mode disabled")
+    ? String(
+      localized: "appIntent.observationMode.result.enabled",
+      defaultValue: "Observation mode enabled",
+      bundle: .module
+    )
+    : String(
+      localized: "appIntent.observationMode.result.disabled",
+      defaultValue: "Observation mode disabled",
+      bundle: .module
+    )
 
     return .result(dialog: IntentDialog(stringLiteral: statusMessage))
   }

--- a/CriticalMapsKit/Sources/AppIntentFeature/README.md
+++ b/CriticalMapsKit/Sources/AppIntentFeature/README.md
@@ -1,0 +1,33 @@
+# AppIntents Integration
+
+This module provides AppIntents support for controlling CriticalMaps settings through Shortcuts.
+
+## Features
+
+### ObservationModeIntent
+
+Allows users to control the `isObservationModeEnabled` setting through Shortcuts app automation.
+
+#### Parameters
+- `enableObservationMode`: Boolean parameter to enable or disable observation mode
+
+#### Usage in Shortcuts
+1. Open the Shortcuts app
+2. Create a new shortcut
+3. Add the "Toggle Observation Mode" action
+4. Set the parameter to enable/disable observation mode
+5. Configure automation triggers like location-based triggers
+
+#### Location-based Automation Example
+1. Create a shortcut with the ObservationModeIntent
+2. Set up automation based on location:
+   - **Arriving at Critical Mass location**: Set `enableObservationMode` to `false` (participate in ride)
+   - **Leaving Critical Mass location**: Set `enableObservationMode` to `true` (observe only)
+
+## Integration
+
+The AppIntents module is automatically included in the main app when building through Xcode. The `CriticalMapsShortcuts` provides suggested shortcuts that users can easily add to their shortcuts library.
+
+## Requirements
+
+- Xcode project must include the AppIntents target in packageProductDependencies

--- a/CriticalMapsKit/Sources/L10n/Generated/L10n.swift
+++ b/CriticalMapsKit/Sources/L10n/Generated/L10n.swift
@@ -266,6 +266,14 @@ public enum L10n {
       }
     }
   }
+  public enum RideEvent {
+    public enum ContextMenu {
+      /// Copy Coordinates
+      public static let copyCoordinates = L10n.tr("Localizable", "rideEvent.contextMenu.copyCoordinates", fallback: "Copy Coordinates")
+      /// Copy Location Name
+      public static let copyLocationName = L10n.tr("Localizable", "rideEvent.contextMenu.copyLocationName", fallback: "Copy Location Name")
+    }
+  }
   public enum RideEventSettings {
     public enum RideTypes {
       /// Select which types of ride events you'd like to be notified about when they occur near your location.

--- a/CriticalMapsKit/Sources/L10n/Generated/L10n.swift
+++ b/CriticalMapsKit/Sources/L10n/Generated/L10n.swift
@@ -58,6 +58,52 @@ public enum L10n {
       public static let watching = L10n.tr("Localizable", "appCore.viewingModeAlert.watching", fallback: "Watching")
     }
   }
+  public enum AppIntent {
+    public enum ObservationMode {
+      /// Enable or disable observation mode in CriticalMaps
+      public static let description = L10n.tr("Localizable", "appIntent.observationMode.description", fallback: "Enable or disable observation mode in CriticalMaps")
+      /// Toggle Observation Mode
+      public static let title = L10n.tr("Localizable", "appIntent.observationMode.title", fallback: "Toggle Observation Mode")
+      public enum Parameter {
+        /// Whether to enable or disable observation mode
+        public static let description = L10n.tr("Localizable", "appIntent.observationMode.parameter.description", fallback: "Whether to enable or disable observation mode")
+        /// Enable Observation Mode
+        public static let title = L10n.tr("Localizable", "appIntent.observationMode.parameter.title", fallback: "Enable Observation Mode")
+      }
+      public enum Result {
+        /// Observation mode disabled
+        public static let disabled = L10n.tr("Localizable", "appIntent.observationMode.result.disabled", fallback: "Observation mode disabled")
+        /// Observation mode enabled
+        public static let enabled = L10n.tr("Localizable", "appIntent.observationMode.result.enabled", fallback: "Observation mode enabled")
+      }
+      public enum Shortcut {
+        /// Observation Mode
+        public static let title = L10n.tr("Localizable", "appIntent.observationMode.shortcut.title", fallback: "Observation Mode")
+        public enum Phrase {
+          /// Disable observation mode in %@
+          public static func disable(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.disable", String(describing: p1), fallback: "Disable observation mode in %@")
+          }
+          /// Enable observation mode in %@
+          public static func enable(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.enable", String(describing: p1), fallback: "Enable observation mode in %@")
+          }
+          /// Toggle observation mode in %@
+          public static func toggle(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.toggle", String(describing: p1), fallback: "Toggle observation mode in %@")
+          }
+          /// Turn off observation mode in %@
+          public static func turnOff(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.turnOff", String(describing: p1), fallback: "Turn off observation mode in %@")
+          }
+          /// Turn on observation mode in %@
+          public static func turnOn(_ p1: Any) -> String {
+            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.turnOn", String(describing: p1), fallback: "Turn on observation mode in %@")
+          }
+        }
+      }
+    }
+  }
   public enum AppView {
     public enum Overlay {
       /// Next update

--- a/CriticalMapsKit/Sources/L10n/Generated/L10n.swift
+++ b/CriticalMapsKit/Sources/L10n/Generated/L10n.swift
@@ -58,52 +58,6 @@ public enum L10n {
       public static let watching = L10n.tr("Localizable", "appCore.viewingModeAlert.watching", fallback: "Watching")
     }
   }
-  public enum AppIntent {
-    public enum ObservationMode {
-      /// Enable or disable observation mode in CriticalMaps
-      public static let description = L10n.tr("Localizable", "appIntent.observationMode.description", fallback: "Enable or disable observation mode in CriticalMaps")
-      /// Toggle Observation Mode
-      public static let title = L10n.tr("Localizable", "appIntent.observationMode.title", fallback: "Toggle Observation Mode")
-      public enum Parameter {
-        /// Whether to enable or disable observation mode
-        public static let description = L10n.tr("Localizable", "appIntent.observationMode.parameter.description", fallback: "Whether to enable or disable observation mode")
-        /// Enable Observation Mode
-        public static let title = L10n.tr("Localizable", "appIntent.observationMode.parameter.title", fallback: "Enable Observation Mode")
-      }
-      public enum Result {
-        /// Observation mode disabled
-        public static let disabled = L10n.tr("Localizable", "appIntent.observationMode.result.disabled", fallback: "Observation mode disabled")
-        /// Observation mode enabled
-        public static let enabled = L10n.tr("Localizable", "appIntent.observationMode.result.enabled", fallback: "Observation mode enabled")
-      }
-      public enum Shortcut {
-        /// Observation Mode
-        public static let title = L10n.tr("Localizable", "appIntent.observationMode.shortcut.title", fallback: "Observation Mode")
-        public enum Phrase {
-          /// Disable observation mode in %@
-          public static func disable(_ p1: Any) -> String {
-            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.disable", String(describing: p1), fallback: "Disable observation mode in %@")
-          }
-          /// Enable observation mode in %@
-          public static func enable(_ p1: Any) -> String {
-            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.enable", String(describing: p1), fallback: "Enable observation mode in %@")
-          }
-          /// Toggle observation mode in %@
-          public static func toggle(_ p1: Any) -> String {
-            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.toggle", String(describing: p1), fallback: "Toggle observation mode in %@")
-          }
-          /// Turn off observation mode in %@
-          public static func turnOff(_ p1: Any) -> String {
-            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.turnOff", String(describing: p1), fallback: "Turn off observation mode in %@")
-          }
-          /// Turn on observation mode in %@
-          public static func turnOn(_ p1: Any) -> String {
-            return L10n.tr("Localizable", "appIntent.observationMode.shortcut.phrase.turnOn", String(describing: p1), fallback: "Turn on observation mode in %@")
-          }
-        }
-      }
-    }
-  }
   public enum AppView {
     public enum Overlay {
       /// Next update

--- a/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
@@ -332,16 +332,3 @@
 "social.feed.loading" = "Feed wird geladen";
 
 "map.location.request.desciption" = "Der Standort verbessert diese App. Bitte gewähre uns Zugriff.";
-
-"appIntent.observationMode.title" = "Beobachtungsmodus umschalten";
-"appIntent.observationMode.description" = "Beobachtungsmodus in CriticalMaps aktivieren oder deaktivieren";
-"appIntent.observationMode.parameter.title" = "Beobachtungsmodus aktivieren";
-"appIntent.observationMode.parameter.description" = "Ob der Beobachtungsmodus aktiviert oder deaktiviert werden soll";
-"appIntent.observationMode.result.enabled" = "Beobachtungsmodus aktiviert";
-"appIntent.observationMode.result.disabled" = "Beobachtungsmodus deaktiviert";
-"appIntent.observationMode.shortcut.title" = "Beobachtungsmodus";
-"appIntent.observationMode.shortcut.phrase.enable" = "Beobachtungsmodus in %@ aktivieren";
-"appIntent.observationMode.shortcut.phrase.turnOn" = "Beobachtungsmodus in %@ einschalten";
-"appIntent.observationMode.shortcut.phrase.disable" = "Beobachtungsmodus in %@ deaktivieren";
-"appIntent.observationMode.shortcut.phrase.turnOff" = "Beobachtungsmodus in %@ ausschalten";
-"appIntent.observationMode.shortcut.phrase.toggle" = "Beobachtungsmodus in %@ umschalten";

--- a/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
@@ -332,3 +332,16 @@
 "social.feed.loading" = "Feed wird geladen";
 
 "map.location.request.desciption" = "Der Standort verbessert diese App. Bitte gewähre uns Zugriff.";
+
+"appIntent.observationMode.title" = "Beobachtungsmodus umschalten";
+"appIntent.observationMode.description" = "Beobachtungsmodus in CriticalMaps aktivieren oder deaktivieren";
+"appIntent.observationMode.parameter.title" = "Beobachtungsmodus aktivieren";
+"appIntent.observationMode.parameter.description" = "Ob der Beobachtungsmodus aktiviert oder deaktiviert werden soll";
+"appIntent.observationMode.result.enabled" = "Beobachtungsmodus aktiviert";
+"appIntent.observationMode.result.disabled" = "Beobachtungsmodus deaktiviert";
+"appIntent.observationMode.shortcut.title" = "Beobachtungsmodus";
+"appIntent.observationMode.shortcut.phrase.enable" = "Beobachtungsmodus in %@ aktivieren";
+"appIntent.observationMode.shortcut.phrase.turnOn" = "Beobachtungsmodus in %@ einschalten";
+"appIntent.observationMode.shortcut.phrase.disable" = "Beobachtungsmodus in %@ deaktivieren";
+"appIntent.observationMode.shortcut.phrase.turnOff" = "Beobachtungsmodus in %@ ausschalten";
+"appIntent.observationMode.shortcut.phrase.toggle" = "Beobachtungsmodus in %@ umschalten";

--- a/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
@@ -332,3 +332,6 @@
 "social.feed.loading" = "Feed wird geladen";
 
 "map.location.request.desciption" = "Der Standort verbessert diese App. Bitte gewähre uns Zugriff.";
+
+"rideEvent.contextMenu.copyCoordinates" = "Koordinaten kopieren";
+"rideEvent.contextMenu.copyLocationName" = "Ortsname kopieren";

--- a/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
@@ -332,16 +332,3 @@
 "social.feed.loading" = "Loading Feed";
 
 "map.location.request.desciption" = "Location makes this app better. Please consider giving us access.";
-
-"appIntent.observationMode.title" = "Toggle Observation Mode";
-"appIntent.observationMode.description" = "Enable or disable observation mode in CriticalMaps";
-"appIntent.observationMode.parameter.title" = "Enable Observation Mode";
-"appIntent.observationMode.parameter.description" = "Whether to enable or disable observation mode";
-"appIntent.observationMode.result.enabled" = "Observation mode enabled";
-"appIntent.observationMode.result.disabled" = "Observation mode disabled";
-"appIntent.observationMode.shortcut.title" = "Observation Mode";
-"appIntent.observationMode.shortcut.phrase.enable" = "Enable observation mode in %@";
-"appIntent.observationMode.shortcut.phrase.turnOn" = "Turn on observation mode in %@";
-"appIntent.observationMode.shortcut.phrase.disable" = "Disable observation mode in %@";
-"appIntent.observationMode.shortcut.phrase.turnOff" = "Turn off observation mode in %@";
-"appIntent.observationMode.shortcut.phrase.toggle" = "Toggle observation mode in %@";

--- a/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
@@ -332,3 +332,6 @@
 "social.feed.loading" = "Loading Feed";
 
 "map.location.request.desciption" = "Location makes this app better. Please consider giving us access.";
+
+"rideEvent.contextMenu.copyCoordinates" = "Copy Coordinates";
+"rideEvent.contextMenu.copyLocationName" = "Copy Location Name";

--- a/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
@@ -332,3 +332,16 @@
 "social.feed.loading" = "Loading Feed";
 
 "map.location.request.desciption" = "Location makes this app better. Please consider giving us access.";
+
+"appIntent.observationMode.title" = "Toggle Observation Mode";
+"appIntent.observationMode.description" = "Enable or disable observation mode in CriticalMaps";
+"appIntent.observationMode.parameter.title" = "Enable Observation Mode";
+"appIntent.observationMode.parameter.description" = "Whether to enable or disable observation mode";
+"appIntent.observationMode.result.enabled" = "Observation mode enabled";
+"appIntent.observationMode.result.disabled" = "Observation mode disabled";
+"appIntent.observationMode.shortcut.title" = "Observation Mode";
+"appIntent.observationMode.shortcut.phrase.enable" = "Enable observation mode in %@";
+"appIntent.observationMode.shortcut.phrase.turnOn" = "Turn on observation mode in %@";
+"appIntent.observationMode.shortcut.phrase.disable" = "Disable observation mode in %@";
+"appIntent.observationMode.shortcut.phrase.turnOff" = "Turn off observation mode in %@";
+"appIntent.observationMode.shortcut.phrase.toggle" = "Toggle observation mode in %@";

--- a/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
@@ -332,3 +332,16 @@
 "social.feed.loading" = "Cargando feed";
 
 "map.location.request.desciption" = "La ubicación mejora esta app. Por favor, danos acceso.";
+
+"appIntent.observationMode.title" = "Alternar modo de observación";
+"appIntent.observationMode.description" = "Activar o desactivar el modo de observación en CriticalMaps";
+"appIntent.observationMode.parameter.title" = "Activar modo de observación";
+"appIntent.observationMode.parameter.description" = "Si activar o desactivar el modo de observación";
+"appIntent.observationMode.result.enabled" = "Modo de observación activado";
+"appIntent.observationMode.result.disabled" = "Modo de observación desactivado";
+"appIntent.observationMode.shortcut.title" = "Modo de observación";
+"appIntent.observationMode.shortcut.phrase.enable" = "Activar modo de observación en %@";
+"appIntent.observationMode.shortcut.phrase.turnOn" = "Encender modo de observación en %@";
+"appIntent.observationMode.shortcut.phrase.disable" = "Desactivar modo de observación en %@";
+"appIntent.observationMode.shortcut.phrase.turnOff" = "Apagar modo de observación en %@";
+"appIntent.observationMode.shortcut.phrase.toggle" = "Alternar modo de observación en %@";

--- a/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
@@ -332,16 +332,3 @@
 "social.feed.loading" = "Cargando feed";
 
 "map.location.request.desciption" = "La ubicación mejora esta app. Por favor, danos acceso.";
-
-"appIntent.observationMode.title" = "Alternar modo de observación";
-"appIntent.observationMode.description" = "Activar o desactivar el modo de observación en CriticalMaps";
-"appIntent.observationMode.parameter.title" = "Activar modo de observación";
-"appIntent.observationMode.parameter.description" = "Si activar o desactivar el modo de observación";
-"appIntent.observationMode.result.enabled" = "Modo de observación activado";
-"appIntent.observationMode.result.disabled" = "Modo de observación desactivado";
-"appIntent.observationMode.shortcut.title" = "Modo de observación";
-"appIntent.observationMode.shortcut.phrase.enable" = "Activar modo de observación en %@";
-"appIntent.observationMode.shortcut.phrase.turnOn" = "Encender modo de observación en %@";
-"appIntent.observationMode.shortcut.phrase.disable" = "Desactivar modo de observación en %@";
-"appIntent.observationMode.shortcut.phrase.turnOff" = "Apagar modo de observación en %@";
-"appIntent.observationMode.shortcut.phrase.toggle" = "Alternar modo de observación en %@";

--- a/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
@@ -332,3 +332,6 @@
 "social.feed.loading" = "Cargando feed";
 
 "map.location.request.desciption" = "La ubicación mejora esta app. Por favor, danos acceso.";
+
+"rideEvent.contextMenu.copyCoordinates" = "Copiar coordenadas";
+"rideEvent.contextMenu.copyLocationName" = "Copiar nombre del lugar";

--- a/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
@@ -332,16 +332,3 @@
 "social.feed.loading" = "Chargement du fil";
 
 "map.location.request.desciption" = "La localisation rend cette app meilleure. Merci de nous donner l'accès.";
-
-"appIntent.observationMode.title" = "Basculer le mode observation";
-"appIntent.observationMode.description" = "Activer ou désactiver le mode observation dans CriticalMaps";
-"appIntent.observationMode.parameter.title" = "Activer le mode observation";
-"appIntent.observationMode.parameter.description" = "Activer ou désactiver le mode observation";
-"appIntent.observationMode.result.enabled" = "Mode observation activé";
-"appIntent.observationMode.result.disabled" = "Mode observation désactivé";
-"appIntent.observationMode.shortcut.title" = "Mode observation";
-"appIntent.observationMode.shortcut.phrase.enable" = "Activer le mode observation dans %@";
-"appIntent.observationMode.shortcut.phrase.turnOn" = "Allumer le mode observation dans %@";
-"appIntent.observationMode.shortcut.phrase.disable" = "Désactiver le mode observation dans %@";
-"appIntent.observationMode.shortcut.phrase.turnOff" = "Éteindre le mode observation dans %@";
-"appIntent.observationMode.shortcut.phrase.toggle" = "Basculer le mode observation dans %@";

--- a/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
@@ -332,3 +332,6 @@
 "social.feed.loading" = "Chargement du fil";
 
 "map.location.request.desciption" = "La localisation rend cette app meilleure. Merci de nous donner l'accès.";
+
+"rideEvent.contextMenu.copyCoordinates" = "Copier les coordonnées";
+"rideEvent.contextMenu.copyLocationName" = "Copier le nom du lieu";

--- a/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
@@ -331,4 +331,17 @@
 "social.error.sendMessage" = "Impossible d’envoyer le message du chat";
 "social.feed.loading" = "Chargement du fil";
 
-"map.location.request.desciption" = "La localisation rend cette app meilleure. Merci de nous donner l’accès.";
+"map.location.request.desciption" = "La localisation rend cette app meilleure. Merci de nous donner l'accès.";
+
+"appIntent.observationMode.title" = "Basculer le mode observation";
+"appIntent.observationMode.description" = "Activer ou désactiver le mode observation dans CriticalMaps";
+"appIntent.observationMode.parameter.title" = "Activer le mode observation";
+"appIntent.observationMode.parameter.description" = "Activer ou désactiver le mode observation";
+"appIntent.observationMode.result.enabled" = "Mode observation activé";
+"appIntent.observationMode.result.disabled" = "Mode observation désactivé";
+"appIntent.observationMode.shortcut.title" = "Mode observation";
+"appIntent.observationMode.shortcut.phrase.enable" = "Activer le mode observation dans %@";
+"appIntent.observationMode.shortcut.phrase.turnOn" = "Allumer le mode observation dans %@";
+"appIntent.observationMode.shortcut.phrase.disable" = "Désactiver le mode observation dans %@";
+"appIntent.observationMode.shortcut.phrase.turnOff" = "Éteindre le mode observation dans %@";
+"appIntent.observationMode.shortcut.phrase.toggle" = "Basculer le mode observation dans %@";

--- a/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
@@ -332,16 +332,3 @@
 "social.feed.loading" = "Caricamento feed";
 
 "map.location.request.desciption" = "La tua posizione rende questa app migliore. Per favore concedici l'accesso.";
-
-"appIntent.observationMode.title" = "Attiva modalità osservazione";
-"appIntent.observationMode.description" = "Attivare o disattivare la modalità osservazione in CriticalMaps";
-"appIntent.observationMode.parameter.title" = "Attiva modalità osservazione";
-"appIntent.observationMode.parameter.description" = "Se attivare o disattivare la modalità osservazione";
-"appIntent.observationMode.result.enabled" = "Modalità osservazione attivata";
-"appIntent.observationMode.result.disabled" = "Modalità osservazione disattivata";
-"appIntent.observationMode.shortcut.title" = "Modalità osservazione";
-"appIntent.observationMode.shortcut.phrase.enable" = "Attiva modalità osservazione in %@";
-"appIntent.observationMode.shortcut.phrase.turnOn" = "Accendi modalità osservazione in %@";
-"appIntent.observationMode.shortcut.phrase.disable" = "Disattiva modalità osservazione in %@";
-"appIntent.observationMode.shortcut.phrase.turnOff" = "Spegni modalità osservazione in %@";
-"appIntent.observationMode.shortcut.phrase.toggle" = "Commuta modalità osservazione in %@";

--- a/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
@@ -331,4 +331,17 @@
 "social.error.sendMessage" = "Impossibile inviare il messaggio della chat";
 "social.feed.loading" = "Caricamento feed";
 
-"map.location.request.desciption" = "La tua posizione rende questa app migliore. Per favore concedici l’accesso.";
+"map.location.request.desciption" = "La tua posizione rende questa app migliore. Per favore concedici l'accesso.";
+
+"appIntent.observationMode.title" = "Attiva modalità osservazione";
+"appIntent.observationMode.description" = "Attivare o disattivare la modalità osservazione in CriticalMaps";
+"appIntent.observationMode.parameter.title" = "Attiva modalità osservazione";
+"appIntent.observationMode.parameter.description" = "Se attivare o disattivare la modalità osservazione";
+"appIntent.observationMode.result.enabled" = "Modalità osservazione attivata";
+"appIntent.observationMode.result.disabled" = "Modalità osservazione disattivata";
+"appIntent.observationMode.shortcut.title" = "Modalità osservazione";
+"appIntent.observationMode.shortcut.phrase.enable" = "Attiva modalità osservazione in %@";
+"appIntent.observationMode.shortcut.phrase.turnOn" = "Accendi modalità osservazione in %@";
+"appIntent.observationMode.shortcut.phrase.disable" = "Disattiva modalità osservazione in %@";
+"appIntent.observationMode.shortcut.phrase.turnOff" = "Spegni modalità osservazione in %@";
+"appIntent.observationMode.shortcut.phrase.toggle" = "Commuta modalità osservazione in %@";

--- a/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
@@ -332,3 +332,6 @@
 "social.feed.loading" = "Caricamento feed";
 
 "map.location.request.desciption" = "La tua posizione rende questa app migliore. Per favore concedici l'accesso.";
+
+"rideEvent.contextMenu.copyCoordinates" = "Copia coordinate";
+"rideEvent.contextMenu.copyLocationName" = "Copia nome del luogo";

--- a/CriticalMapsKit/Sources/SharedModels/API/Coordinate.swift
+++ b/CriticalMapsKit/Sources/SharedModels/API/Coordinate.swift
@@ -34,3 +34,16 @@ public extension CLLocation {
     self.init(latitude: coordinate.latitude, longitude: coordinate.longitude)
   }
 }
+
+public extension Coordinate {
+  /// Formats the coordinate in the format "42,47221° N, 2,43165° W"
+  var formattedForCopying: String {
+    let latDirection = latitude >= 0 ? "N" : "S"
+    let lonDirection = longitude >= 0 ? "E" : "W"
+
+    let absLatitude = abs(latitude)
+    let absLongitude = abs(longitude)
+
+    return String(format: "%.5f° %@, %.5f° %@", absLatitude, latDirection, absLongitude, lonDirection)
+  }
+}

--- a/CriticalMapsKit/Tests/AppFeatureTests/AppFeatureFeatureTests.swift
+++ b/CriticalMapsKit/Tests/AppFeatureTests/AppFeatureFeatureTests.swift
@@ -117,11 +117,11 @@ struct AppFeatureTests {
       $0.mapFeatureState.rideEvents = events
       $0.isEventListPresented = true
     }
-    
     await store.receive(\.map.focusNextRide)
     
-    await store.send(.binding(.set(\.isEventListPresented, false))) {
+    await store.send(.dismissEventList) {
       $0.isEventListPresented = false
+      $0.mapFeatureState.rideEvents = []
     }
   }
   

--- a/CriticalMapsKit/Tests/AppFeatureTests/AppFeatureFeatureTests.swift
+++ b/CriticalMapsKit/Tests/AppFeatureTests/AppFeatureFeatureTests.swift
@@ -85,28 +85,42 @@ struct AppFeatureTests {
     let store = TestStore(
       initialState: appState,
       reducer: { AppFeature() }
-    )
+    ) {
+      $0.feedbackGenerator = .noop
+    }
 
-    await store.send(.binding(.set(\.isEventListPresented, true))) {
+    await store.send(.didTapNextRideOverlayButton) {
       $0.mapFeatureState.rideEvents = events
       $0.isEventListPresented = true
     }
+    
+    await store.receive(\.map.focusNextRide)
   }
 
   @Test
   func actionSetEventsBottomSheet_setsValue_andSetEmptyMapFeatureRideEvents() async {
     var appState = AppFeature.State()
-    appState.eventListPresentation = .fraction(0.3)
-    let events = [Ride.mock1, .mock2]
-    appState.mapFeatureState.rideEvents = events
-    
+    let events = [
+      Ride.mock1,
+      Ride.mock2
+    ]
+    appState.nextRideState.rideEvents = events
+
     let store = TestStore(
       initialState: appState,
       reducer: { AppFeature() }
-    )
+    ) {
+      $0.feedbackGenerator = .noop
+    }
+
+    await store.send(.didTapNextRideOverlayButton) {
+      $0.mapFeatureState.rideEvents = events
+      $0.isEventListPresented = true
+    }
+    
+    await store.receive(\.map.focusNextRide)
     
     await store.send(.binding(.set(\.isEventListPresented, false))) {
-      $0.mapFeatureState.rideEvents = []
       $0.isEventListPresented = false
     }
   }

--- a/CriticalMapsKit/Tests/HelperTests/CoordinateFormattingTests.swift
+++ b/CriticalMapsKit/Tests/HelperTests/CoordinateFormattingTests.swift
@@ -1,0 +1,187 @@
+import SharedModels
+import Testing
+
+@Suite
+struct CoordinateFormattingTests {
+
+  @Test("Format positive coordinates (Northern/Eastern hemisphere)")
+  func formatPositiveCoordinates() {
+    // given - Berlin coordinates
+    let berlin = Coordinate(latitude: 52.524657, longitude: 13.413939)
+
+    // when
+    let formatted = berlin.formattedForCopying
+
+    // then
+    #expect(formatted == "52.52466° N, 13.41394° E")
+  }
+
+  @Test("Format negative longitude (Western hemisphere)")
+  func formatNegativeLongitude() {
+    // given - San Francisco coordinates
+    let sanFrancisco = Coordinate(latitude: 37.774929, longitude: -122.419416)
+
+    // when
+    let formatted = sanFrancisco.formattedForCopying
+
+    // then
+    #expect(formatted == "37.77493° N, 122.41942° W")
+  }
+
+  @Test("Format negative latitude (Southern hemisphere)")
+  func formatNegativeLatitude() {
+    // given - Melbourne coordinates
+    let melbourne = Coordinate(latitude: -37.813628, longitude: 144.963058)
+
+    // when
+    let formatted = melbourne.formattedForCopying
+
+    // then
+    #expect(formatted == "37.81363° S, 144.96306° E")
+  }
+
+  @Test("Format both negative coordinates (Southern/Western hemisphere)")
+  func formatBothNegativeCoordinates() {
+    // given - Santiago, Chile coordinates
+    let santiago = Coordinate(latitude: -33.448457, longitude: -70.669265)
+
+    // when
+    let formatted = santiago.formattedForCopying
+
+    // then
+    #expect(formatted == "33.44846° S, 70.66926° W")
+  }
+
+  @Test("Format coordinates at equator and prime meridian")
+  func formatZeroCoordinates() {
+    // given - Null Island (0,0)
+    let nullIsland = Coordinate(latitude: 0.0, longitude: 0.0)
+
+    // when
+    let formatted = nullIsland.formattedForCopying
+
+    // then
+    #expect(formatted == "0.00000° N, 0.00000° E")
+  }
+
+  @Test("Format coordinates with small decimal values")
+  func formatSmallDecimalValues() {
+    // given - very precise coordinates
+    let precise = Coordinate(latitude: 0.000001, longitude: -0.000001)
+
+    // when
+    let formatted = precise.formattedForCopying
+
+    // then
+    #expect(formatted == "0.00000° N, 0.00000° W")
+  }
+
+  @Test("Format coordinates using existing test data - Alexander Platz")
+  func formatAlexanderPlatz() {
+    // given
+    let alexanderPlatz = Coordinate.TestData.alexanderPlatz
+
+    // when
+    let formatted = alexanderPlatz.formattedForCopying
+
+    // then
+    #expect(formatted == "52.52466° N, 13.41394° E")
+  }
+
+  @Test("Format coordinates using existing test data - Rendsburg")
+  func formatRendsburg() {
+    // given
+    let rendsburg = Coordinate.TestData.rendsburg
+
+    // when
+    let formatted = rendsburg.formattedForCopying
+
+    // then
+    #expect(formatted == "54.30855° N, 9.65664° E")
+  }
+
+  @Test("Verify decimal precision is exactly 5 places")
+  func verifyDecimalPrecision() {
+    // given - coordinate with many decimal places
+    let manyDecimals = Coordinate(latitude: 52.12345678901234, longitude: 13.98765432109876)
+
+    // when
+    let formatted = manyDecimals.formattedForCopying
+
+    // then
+    #expect(formatted == "52.12346° N, 13.98765° E")
+
+    // Verify the format matches the expected pattern
+    let components = formatted.components(separatedBy: ", ")
+    #expect(components.count == 2)
+
+    // Check latitude part
+    let latPart = components[0]
+    #expect(latPart.hasSuffix("° N"))
+    let latValue = latPart.replacingOccurrences(of: "° N", with: "")
+    let latDecimalPlaces = latValue.components(separatedBy: ".")[1].count
+    #expect(latDecimalPlaces == 5)
+
+    // Check longitude part
+    let lngPart = components[1]
+    #expect(lngPart.hasSuffix("° E"))
+    let lngValue = lngPart.replacingOccurrences(of: "° E", with: "")
+    let lngDecimalPlaces = lngValue.components(separatedBy: ".")[1].count
+    #expect(lngDecimalPlaces == 5)
+  }
+
+  @Test("Format coordinates at maximum valid latitude")
+  func formatMaxLatitude() {
+    // given - maximum valid latitude (90°)
+    let maxLat = Coordinate(latitude: 90.0, longitude: 0.0)
+
+    // when
+    let formatted = maxLat.formattedForCopying
+
+    // then
+    #expect(formatted == "90.00000° N, 0.00000° E")
+  }
+
+  @Test("Format coordinates at minimum valid latitude")
+  func formatMinLatitude() {
+    // given - minimum valid latitude (-90°)
+    let minLat = Coordinate(latitude: -90.0, longitude: 0.0)
+
+    // when
+    let formatted = minLat.formattedForCopying
+
+    // then
+    #expect(formatted == "90.00000° S, 0.00000° E")
+  }
+
+  @Test("Format coordinates at maximum valid longitude")
+  func formatMaxLongitude() {
+    // given - maximum valid longitude (180°)
+    let maxLng = Coordinate(latitude: 0.0, longitude: 180.0)
+
+    // when
+    let formatted = maxLng.formattedForCopying
+
+    // then
+    #expect(formatted == "0.00000° N, 180.00000° E")
+  }
+
+  @Test("Format coordinates at minimum valid longitude")
+  func formatMinLongitude() {
+    // given - minimum valid longitude (-180°)
+    let minLng = Coordinate(latitude: 0.0, longitude: -180.0)
+
+    // when
+    let formatted = minLng.formattedForCopying
+
+    // then
+    #expect(formatted == "0.00000° N, 180.00000° W")
+  }
+}
+
+extension Coordinate {
+  enum TestData {
+    static let rendsburg = Coordinate(latitude: 54.308547, longitude: 9.656645)
+    static let alexanderPlatz = Coordinate(latitude: 52.524657, longitude: 13.413939)
+  }
+}

--- a/CriticalMapsKit/Tests/NextRideFeatureTests/Mocks/CoordinateTestData.swift
+++ b/CriticalMapsKit/Tests/NextRideFeatureTests/Mocks/CoordinateTestData.swift
@@ -1,10 +1,3 @@
-//
-//  CoordinateTestData.swift
-//  
-//
-//  Created by Malte on 07.06.21.
-//
-
 import Foundation
 import SharedModels
 

--- a/iOS/App.swift
+++ b/iOS/App.swift
@@ -1,9 +1,10 @@
 import AppFeature
+import AppIntentFeature
 import ComposableArchitecture
 import SwiftUI
 
 @main
-struct CriticalMapsApp: App {  
+struct CriticalMapsApp: App {
   @MainActor
   static let store = Store(initialState: AppFeature.State()) {
     AppFeature()
@@ -12,6 +13,12 @@ struct CriticalMapsApp: App {
   var body: some Scene {
     WindowGroup {
       AppView(store: Self.store)
+    }
+  }
+
+  init() {
+    if #available(iOS 16.0, *) {
+      CriticalMapsShortcuts.updateAppShortcutParameters()
     }
   }
 }

--- a/iOS/App.swift
+++ b/iOS/App.swift
@@ -17,8 +17,6 @@ struct CriticalMapsApp: App {
   }
 
   init() {
-    if #available(iOS 16.0, *) {
-      CriticalMapsShortcuts.updateAppShortcutParameters()
-    }
+    CriticalMapsShortcuts.updateAppShortcutParameters()
   }
 }

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -92,6 +92,8 @@
 	<string>CriticalMaps needs the access to be able to share your location with other Critical Maps users.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>CriticalMaps needs the access to be able to share your location with other Critical Maps users.</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

To increase the privacy of the app so that it is not accidentally tracking your location from places you do not want to share, this feature introduces a way to set the observation mode from the shortcuts app and also it can be enabled/disabled via Siri when saying one of the following:

| Siri commands |
|--------|
| Enable observation mode in Critical Maps |
| Turn on observation mode in Critical Maps |
| Disable observation mode in Critical Maps |
| Turn off observation mode in Critical Maps |
| Toggle observation mode in Critical Maps | 


## 👀 See

https://github.com/user-attachments/assets/b2dee06d-bb66-494e-bf13-11d8a5dcd7b2