### PR TITLE
[`Feature`] add gpx overlay

### DIFF
--- a/CriticalMapsKit/Sources/AppFeature/InfoOverlayView.swift
+++ b/CriticalMapsKit/Sources/AppFeature/InfoOverlayView.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import Helpers
 import L10n
 import SettingsFeature
+import SharedModels
 import Styleguide
 import SwiftUI
 import SwiftUIHelpers
@@ -127,6 +128,7 @@ private struct InfoOverlayLegacyContent: View {
 
 private struct InfoOverlayExpandedContent: View {
   @Binding var isExpanded: Bool
+  @Shared(.userSettings) private var userSettings
 
   let cycleStartTime: Date?
   let ridersCountLabel: String
@@ -150,12 +152,53 @@ private struct InfoOverlayExpandedContent: View {
       }
 
       PrivacyStatusTile(isInPrivacyZone: isInPrivacyZone)
+
+      if let route = userSettings.gpxRoute {
+        GPXRouteTile(routeName: route.name) {
+          $userSettings.withLock { $0.gpxRoute = nil }
+        }
+      }
     }
     .contentShape(.rect)
     .adaptiveClipShape()
     .onTapGesture {
       withAnimation(.infoOverlay) { isExpanded.toggle() }
     }
+  }
+}
+
+// MARK: - GPX Route Tile
+
+private struct GPXRouteTile: View {
+  let routeName: String?
+  let onRemove: () -> Void
+
+  var body: some View {
+    DataTile("Route") {
+      Button {
+        onRemove()
+      } label: {
+        Image(systemName: "xmark.circle.fill")
+          .font(.title3)
+          .foregroundStyle(Color.textPrimary)
+      }
+      .buttonStyle(.plain)
+    }
+    .overlay(alignment: .bottomLeading) {
+      if let routeName {
+        Text(routeName)
+          .font(.system(size: 9))
+          .foregroundStyle(Color.textPrimary.opacity(0.7))
+          .lineLimit(1)
+          .truncationMode(.tail)
+          .padding(.horizontal, .grid(1))
+          .padding(.bottom, .grid(1))
+      }
+    }
+    .accessibilityLabel("GPX Route: \(routeName ?? "Route")")
+    .accessibilityHint("Double tap to remove")
+    .accessibilityAddTraits(.isButton)
+    .accessibilityAction { onRemove() }
   }
 }
 

--- a/CriticalMapsKit/Sources/AppFeature/InfoOverlayView.swift
+++ b/CriticalMapsKit/Sources/AppFeature/InfoOverlayView.swift
@@ -174,28 +174,28 @@ private struct GPXRouteTile: View {
   let onRemove: () -> Void
 
   var body: some View {
-    DataTile("Route") {
-      Button {
+    DataTile(L10n.AppView.Overlay.route) {
+      Button(role: .destructive) {
         onRemove()
       } label: {
-        Image(systemName: "xmark.circle.fill")
-          .font(.title3)
-          .foregroundStyle(Color.textPrimary)
+        VStack {
+          Image(systemName: "xmark.circle")
+            .font(.pageTitle)
+            .foregroundStyle(.red)
+
+          if let routeName {
+            Text(routeName)
+              .font(.system(size: 9))
+              .foregroundStyle(Color.textPrimary.opacity(0.7))
+              .lineLimit(1)
+              .truncationMode(.tail)
+              .padding(.bottom, .grid(1))
+          }
+        }
       }
       .buttonStyle(.plain)
     }
-    .overlay(alignment: .bottomLeading) {
-      if let routeName {
-        Text(routeName)
-          .font(.system(size: 9))
-          .foregroundStyle(Color.textPrimary.opacity(0.7))
-          .lineLimit(1)
-          .truncationMode(.tail)
-          .padding(.horizontal, .grid(1))
-          .padding(.bottom, .grid(1))
-      }
-    }
-    .accessibilityLabel("GPX Route: \(routeName ?? "Route")")
+    .accessibilityLabel(L10n.AppView.Overlay.route + ": " + (routeName ?? L10n.AppView.Overlay.route))
     .accessibilityHint("Double tap to remove")
     .accessibilityAddTraits(.isButton)
     .accessibilityAction { onRemove() }

--- a/CriticalMapsKit/Sources/L10n/Generated/L10n.swift
+++ b/CriticalMapsKit/Sources/L10n/Generated/L10n.swift
@@ -64,6 +64,8 @@ public enum L10n {
       public static let nextUpdate = L10n.tr("Localizable", "appView.overlay.nextUpdate", fallback: "Next update")
       /// Riders
       public static let riders = L10n.tr("Localizable", "appView.overlay.riders", fallback: "Riders")
+      /// Route
+      public static let route = L10n.tr("Localizable", "appView.overlay.route", fallback: "Route")
     }
   }
   public enum AppearanceSettings {
@@ -428,6 +430,14 @@ public enum L10n {
       public static let detail = L10n.tr("Localizable", "settings.opensource.detail", fallback: "Critical Maps is an open source project and we are looking forward to developers who want to work on critical maps.")
       /// Do you miss features or want to fix a bug?
       public static let title = L10n.tr("Localizable", "settings.opensource.title", fallback: "Do you miss features or want to fix a bug?")
+    }
+    public enum RouteOverlay {
+      /// Import a GPX file to show a route on the map
+      public static let description = L10n.tr("Localizable", "settings.routeOverlay.description", fallback: "Import a GPX file to show a route on the map")
+      /// Import
+      public static let `import` = L10n.tr("Localizable", "settings.routeOverlay.import", fallback: "Import")
+      /// Route Overlay
+      public static let title = L10n.tr("Localizable", "settings.routeOverlay.title", fallback: "Route Overlay")
     }
     public enum Section {
       /// Info

--- a/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/de.lproj/Localizable.strings
@@ -335,3 +335,8 @@
 
 "rideEvent.contextMenu.copyCoordinates" = "Koordinaten kopieren";
 "rideEvent.contextMenu.copyLocationName" = "Ortsname kopieren";
+
+"settings.routeOverlay.title" = "Route einblenden";
+"settings.routeOverlay.description" = "Importiere eine GPX-Datei, um eine Route auf der Karte anzuzeigen";
+"settings.routeOverlay.import" = "Importieren";
+"appView.overlay.route" = "Route";

--- a/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/en.lproj/Localizable.strings
@@ -335,3 +335,8 @@
 
 "rideEvent.contextMenu.copyCoordinates" = "Copy Coordinates";
 "rideEvent.contextMenu.copyLocationName" = "Copy Location Name";
+
+"settings.routeOverlay.title" = "Route Overlay";
+"settings.routeOverlay.description" = "Import a GPX file to show a route on the map";
+"settings.routeOverlay.import" = "Import";
+"appView.overlay.route" = "Route";

--- a/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/es.lproj/Localizable.strings
@@ -335,3 +335,8 @@
 
 "rideEvent.contextMenu.copyCoordinates" = "Copiar coordenadas";
 "rideEvent.contextMenu.copyLocationName" = "Copiar nombre del lugar";
+
+"settings.routeOverlay.title" = "Superposición de ruta";
+"settings.routeOverlay.description" = "Importa un archivo GPX para mostrar una ruta en el mapa";
+"settings.routeOverlay.import" = "Importar";
+"appView.overlay.route" = "Ruta";

--- a/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/fr.lproj/Localizable.strings
@@ -335,3 +335,8 @@
 
 "rideEvent.contextMenu.copyCoordinates" = "Copier les coordonnées";
 "rideEvent.contextMenu.copyLocationName" = "Copier le nom du lieu";
+
+"settings.routeOverlay.title" = "Superposition d'itinéraire";
+"settings.routeOverlay.description" = "Importez un fichier GPX pour afficher un itinéraire sur la carte";
+"settings.routeOverlay.import" = "Importer";
+"appView.overlay.route" = "Itinéraire";

--- a/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/it.lproj/Localizable.strings
@@ -335,3 +335,8 @@
 
 "rideEvent.contextMenu.copyCoordinates" = "Copia coordinate";
 "rideEvent.contextMenu.copyLocationName" = "Copia nome del luogo";
+
+"settings.routeOverlay.title" = "Sovrapponi percorso";
+"settings.routeOverlay.description" = "Importa un file GPX per visualizzare un percorso sulla mappa";
+"settings.routeOverlay.import" = "Importa";
+"appView.overlay.route" = "Percorso";

--- a/CriticalMapsKit/Sources/L10n/Resources/pl.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/pl.lproj/Localizable.strings
@@ -332,3 +332,8 @@
 "social.feed.loading" = "Ładowanie kanału";
 
 "map.location.request.desciption" = "Twoja lokalizacja sprawia, że ta aplikacja działa lepiej. Proszę daj nam dostęp.";
+
+"settings.routeOverlay.title" = "Nakładka trasy";
+"settings.routeOverlay.description" = "Zaimportuj plik GPX, aby wyświetlić trasę na mapie";
+"settings.routeOverlay.import" = "Importuj";
+"appView.overlay.route" = "Trasa";

--- a/CriticalMapsKit/Sources/L10n/Resources/pt-BR.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/pt-BR.lproj/Localizable.strings
@@ -332,3 +332,8 @@
 "social.feed.loading" = "Carregando feed";
 
 "map.location.request.desciption" = "A localização torna este app melhor. Por favor nos dê acesso.";
+
+"settings.routeOverlay.title" = "Sobreposição de rota";
+"settings.routeOverlay.description" = "Importe um arquivo GPX para exibir uma rota no mapa";
+"settings.routeOverlay.import" = "Importar";
+"appView.overlay.route" = "Rota";

--- a/CriticalMapsKit/Sources/L10n/Resources/pt-PT.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/pt-PT.lproj/Localizable.strings
@@ -332,3 +332,8 @@
 "social.feed.loading" = "A carregar feed";
 
 "map.location.request.desciption" = "A localização torna esta app melhor. Por favor dá-nos acesso.";
+
+"settings.routeOverlay.title" = "Sobreposição de rota";
+"settings.routeOverlay.description" = "Importe um ficheiro GPX para mostrar uma rota no mapa";
+"settings.routeOverlay.import" = "Importar";
+"appView.overlay.route" = "Rota";

--- a/CriticalMapsKit/Sources/L10n/Resources/tr.lproj/Localizable.strings
+++ b/CriticalMapsKit/Sources/L10n/Resources/tr.lproj/Localizable.strings
@@ -332,3 +332,8 @@
 "social.feed.loading" = "Akış yükleniyor";
 
 "map.location.request.desciption" = "Konum bu uygulamayı daha iyi yapar. Lütfen bize erişim ver.";
+
+"settings.routeOverlay.title" = "Rota Katmanı";
+"settings.routeOverlay.description" = "Haritada bir rota göstermek için GPX dosyası içe aktarın";
+"settings.routeOverlay.import" = "İçe Aktar";
+"appView.overlay.route" = "Rota";

--- a/CriticalMapsKit/Sources/MapFeature/MapFeatureView.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapFeatureView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 public struct MapFeatureView: View {
   @Environment(\.accessibilityReduceTransparency) var reduceTransparency
   @Shared(.privacyZoneSettings) var privacyZoneSettings: PrivacyZoneSettings
+  @Shared(.userSettings) var userSettings: UserSettings
 
   @Bindable var store: StoreOf<MapFeature>
 
@@ -24,6 +25,7 @@ public struct MapFeatureView: View {
         rideEvents: store.rideEvents,
         privacyZones: privacyZoneSettings.zones,
         canShowPrivacyZonesOnMap: privacyZoneSettings.canShowOnMap,
+        gpxRoute: userSettings.gpxRoute,
         annotationsCount: $store.visibleRidersCount,
         centerRegion: $store.centerRegion,
         centerEventRegion: $store.eventCenter,

--- a/CriticalMapsKit/Sources/MapFeature/MapView.swift
+++ b/CriticalMapsKit/Sources/MapFeature/MapView.swift
@@ -20,6 +20,7 @@ struct MapView: ViewRepresentable {
   var rideEvents: [Ride] = []
   let privacyZones: IdentifiedArrayOf<PrivacyZone>
   let canShowPrivacyZonesOnMap: Bool
+  var gpxRoute: GPXRoute?
 
   var mapMenuShareEventHandler: MenuActionHandle?
   var mapMenuRouteEventHandler: MenuActionHandle?
@@ -31,6 +32,7 @@ struct MapView: ViewRepresentable {
     rideEvents: [Ride] = [],
     privacyZones: IdentifiedArrayOf<PrivacyZone> = [],
     canShowPrivacyZonesOnMap: Bool = false,
+    gpxRoute: GPXRoute? = nil,
     annotationsCount: Binding<Int?>,
     centerRegion: Binding<CoordinateRegion?>,
     centerEventRegion: Binding<CoordinateRegion?>,
@@ -43,6 +45,7 @@ struct MapView: ViewRepresentable {
     self.rideEvents = rideEvents
     self.privacyZones = privacyZones
     self.canShowPrivacyZonesOnMap = canShowPrivacyZonesOnMap
+    self.gpxRoute = gpxRoute
     _annotationsCount = annotationsCount
     _centerRegion = centerRegion
     _centerEventRegion = centerEventRegion
@@ -76,6 +79,8 @@ struct MapView: ViewRepresentable {
     updateRideEvents(in: uiView)
     // privacy zones
     updatePrivacyZoneOverlays(in: uiView)
+    // gpx route
+    updateGPXRouteOverlay(in: uiView)
   }
 
   func setNextRideAnnotation(in mapView: MKMapView) {
@@ -162,6 +167,17 @@ struct MapView: ViewRepresentable {
       mapView.addOverlay(circle)
     }
   }
+
+  func updateGPXRouteOverlay(in mapView: MKMapView) {
+    mapView.removeOverlays(
+      mapView.overlays.filter { $0.title == gpxRouteOverlayTitle }
+    )
+    guard let route = gpxRoute, !route.coordinates.isEmpty else { return }
+    var clCoordinates = route.coordinates.map(\.asCLLocationCoordinate)
+    let polyline = MKPolyline(coordinates: &clCoordinates, count: clCoordinates.count)
+    polyline.title = gpxRouteOverlayTitle
+    mapView.addOverlay(polyline, level: .aboveRoads)
+  }
 }
 
 /// Coordinator to handle MKMapViewDelegate events
@@ -217,8 +233,18 @@ final class MapCoordinator: NSObject, MKMapViewDelegate {
       return renderer
     }
 
+    if let polyline = overlay as? MKPolyline, overlay.title == gpxRouteOverlayTitle {
+      let renderer = MKPolylineRenderer(polyline: polyline)
+      renderer.strokeColor = UIColor.systemBlue.withAlphaComponent(0.8)
+      renderer.lineWidth = 3
+      renderer.lineJoin = .round
+      renderer.lineCap = .round
+      return renderer
+    }
+
     return MKOverlayRenderer(overlay: overlay)
   }
 }
 
 private let privacyZonePrefix = "privacy_zone_"
+private let gpxRouteOverlayTitle = "gpx_route"

--- a/CriticalMapsKit/Sources/SettingsFeature/SettingsFeature.swift
+++ b/CriticalMapsKit/Sources/SettingsFeature/SettingsFeature.swift
@@ -2,6 +2,7 @@ import AcknowList
 import ComposableArchitecture
 import ComposableCoreLocation
 import Helpers
+import L10n
 import MapFeature
 import SharedModels
 import UIApplicationClient
@@ -19,6 +20,11 @@ public struct SettingsFeature: Sendable {
     case guideFeature
     case acknowledgements
   }
+	
+  @CasePathable
+  public enum Alert: Sendable {
+    case gpxImportError
+  }
 
   // MARK: State
 
@@ -30,7 +36,9 @@ public struct SettingsFeature: Sendable {
 
     @Presents
     var destination: Destination.State?
-
+    @Presents
+    var alert: AlertState<Action.Alert>?
+		
     public var isImportingGPXRoute = false
 
     public init() {}
@@ -61,8 +69,10 @@ public struct SettingsFeature: Sendable {
     case binding(BindingAction<State>)
     case view(ViewAction)
     case destination(PresentationAction<Destination.Action>)
+    case alert(PresentationAction<Alert>)
     case openURL(URL)
     case gpxRouteParsed(GPXRoute)
+    case gpxImportFailed(any Error)
 
     public enum ViewAction {
       case acknowledgementsRowTapped
@@ -79,14 +89,16 @@ public struct SettingsFeature: Sendable {
       case gpxFileSelected(Result<URL, any Error>)
       case gpxRouteRemoved
     }
+		
+    public enum Alert: Sendable {
+      case gpxImportError
+    }
   }
 
   // MARK: Reducer
 
   @Dependency(\.continuousClock) var clock
-  @Dependency(\.uiApplicationClient) var uiApplicationClient
   @Dependency(\.locationManager) var locationManager
-  @Dependency(\.dismiss) var dismiss
 
   public var body: some ReducerOf<Self> {
     BindingReducer()
@@ -104,7 +116,10 @@ public struct SettingsFeature: Sendable {
           }
 					
         case .dismiss:
-          return .run { _ in await dismiss() }
+          return .run { _ in
+            @Dependency(\.dismiss) var dismiss
+            await dismiss()
+          }
 					
         case let .observationModeChanged(isObserving):
           guard isObserving != state.userSettings.isObservationModeEnabled else {
@@ -153,18 +168,27 @@ public struct SettingsFeature: Sendable {
           state.isImportingGPXRoute = true
           return .none
 
-        case let .gpxFileSelected(result):
+        case let .gpxFileSelected(.failure(error)):
           state.isImportingGPXRoute = false
-          guard case let .success(url) = result else { return .none }
+          state.alert = .gpxImportFailed(error: error)
+          return .none
+					
+        case let .gpxFileSelected(.success(url)):
+          state.isImportingGPXRoute = false
           return .run { send in
             let accessing = url.startAccessingSecurityScopedResource()
             defer { if accessing { url.stopAccessingSecurityScopedResource() } }
-            guard
-              let data = try? Data(contentsOf: url),
-              var route = GPXParser.parse(data: data)
-            else { return }
-            route.name = url.lastPathComponent
-            await send(.gpxRouteParsed(route))
+            do {
+              guard let data = try? Data(contentsOf: url) else {
+                await send(.gpxImportFailed(URLError(.cannotOpenFile)))
+                return
+              }
+              var route = try GPXParser.parse(data: data)
+              route.name = url.lastPathComponent
+              await send(.gpxRouteParsed(route))
+            } catch {
+              await send(.gpxImportFailed(error))
+            }
           }
 
         case .gpxRouteRemoved:
@@ -172,11 +196,12 @@ public struct SettingsFeature: Sendable {
           return .none
         }
 
-      case .destination:
+      case .destination, .alert:
         return .none
 
       case let .openURL(url):
         return .run { _ in
+          @Dependency(\.uiApplicationClient) var uiApplicationClient
           _ = await uiApplicationClient.open(url, [:])
         }
 
@@ -184,15 +209,21 @@ public struct SettingsFeature: Sendable {
         state.$userSettings.withLock { $0.gpxRoute = route }
         return .none
 
+      case let .gpxImportFailed(error):
+        state.alert = .gpxImportFailed(error: error)
+        return .none
+
       case .binding:
         return .none
       }
     }
     .ifLet(\.$destination, action: \.destination)
+    .ifLet(\.$alert, action: \.alert)
   }
 }
 
 extension SettingsFeature.Destination.State: Equatable, Sendable {}
+extension SettingsFeature.Alert: Equatable {}
 
 // MARK: Helper
 
@@ -224,6 +255,20 @@ public extension SettingsFeature.State {
       case .crowdin:
         URL(string: "https://crowdin.com/project/critical-maps")!
       }
+    }
+  }
+}
+
+public extension AlertState where Action == SettingsFeature.Action.Alert {
+  static func gpxImportFailed(error: any Error) -> Self {
+    AlertState {
+      TextState("Failed to import GPX file")
+    } actions: {
+      ButtonState(action: .gpxImportError) {
+        TextState(L10n.ok)
+      }
+    } message: {
+      TextState(error.localizedDescription)
     }
   }
 }

--- a/CriticalMapsKit/Sources/SettingsFeature/SettingsFeature.swift
+++ b/CriticalMapsKit/Sources/SettingsFeature/SettingsFeature.swift
@@ -159,9 +159,11 @@ public struct SettingsFeature: Sendable {
           return .run { send in
             let accessing = url.startAccessingSecurityScopedResource()
             defer { if accessing { url.stopAccessingSecurityScopedResource() } }
-            guard let data = try? Data(contentsOf: url),
-                  let route = GPXParser.parse(data: data)
+            guard
+              let data = try? Data(contentsOf: url),
+              var route = GPXParser.parse(data: data)
             else { return }
+            route.name = url.lastPathComponent
             await send(.gpxRouteParsed(route))
           }
 

--- a/CriticalMapsKit/Sources/SettingsFeature/SettingsFeature.swift
+++ b/CriticalMapsKit/Sources/SettingsFeature/SettingsFeature.swift
@@ -31,7 +31,7 @@ public struct SettingsFeature: Sendable {
     @Presents
     var destination: Destination.State?
 
-    var isImportingGPXRoute = false
+    public var isImportingGPXRoute = false
 
     public init() {}
 

--- a/CriticalMapsKit/Sources/SettingsFeature/SettingsFeature.swift
+++ b/CriticalMapsKit/Sources/SettingsFeature/SettingsFeature.swift
@@ -31,6 +31,8 @@ public struct SettingsFeature: Sendable {
     @Presents
     var destination: Destination.State?
 
+    var isImportingGPXRoute = false
+
     public init() {}
 
     var versionNumber: String {
@@ -60,6 +62,7 @@ public struct SettingsFeature: Sendable {
     case view(ViewAction)
     case destination(PresentationAction<Destination.Action>)
     case openURL(URL)
+    case gpxRouteParsed(GPXRoute)
 
     public enum ViewAction {
       case acknowledgementsRowTapped
@@ -72,6 +75,9 @@ public struct SettingsFeature: Sendable {
       case observationModeChanged(Bool)
       case infoSectionRowTapped(SettingsFeature.State.InfoSectionRow)
       case supportSectionRowTapped(SettingsFeature.State.SupportSectionRow)
+      case gpxImportButtonTapped
+      case gpxFileSelected(Result<URL, any Error>)
+      case gpxRouteRemoved
     }
   }
 
@@ -142,6 +148,26 @@ public struct SettingsFeature: Sendable {
 
         case let .supportSectionRowTapped(row):
           return .send(.openURL(row.url))
+
+        case .gpxImportButtonTapped:
+          state.isImportingGPXRoute = true
+          return .none
+
+        case let .gpxFileSelected(result):
+          state.isImportingGPXRoute = false
+          guard case let .success(url) = result else { return .none }
+          return .run { send in
+            let accessing = url.startAccessingSecurityScopedResource()
+            defer { if accessing { url.stopAccessingSecurityScopedResource() } }
+            guard let data = try? Data(contentsOf: url),
+                  let route = GPXParser.parse(data: data)
+            else { return }
+            await send(.gpxRouteParsed(route))
+          }
+
+        case .gpxRouteRemoved:
+          state.$userSettings.withLock { $0.gpxRoute = nil }
+          return .none
         }
 
       case .destination:
@@ -151,6 +177,10 @@ public struct SettingsFeature: Sendable {
         return .run { _ in
           _ = await uiApplicationClient.open(url, [:])
         }
+
+      case let .gpxRouteParsed(route):
+        state.$userSettings.withLock { $0.gpxRoute = route }
+        return .none
 
       case .binding:
         return .none

--- a/CriticalMapsKit/Sources/SettingsFeature/SettingsView.swift
+++ b/CriticalMapsKit/Sources/SettingsFeature/SettingsView.swift
@@ -6,6 +6,7 @@ import L10n
 import Styleguide
 import SwiftUI
 import SwiftUIHelpers
+import UniformTypeIdentifiers
 
 /// A view to render the app settings.
 public struct SettingsView: View {
@@ -47,6 +48,10 @@ public struct SettingsView: View {
             }
           }
         )
+      }
+
+      Section {
+        GPXRouteRow(store: store)
       }
 
       Section {
@@ -117,10 +122,61 @@ public struct SettingsView: View {
     .navigationDestination(isPresented: $store.destination.acknowledgements) {
       AcknowListSwiftUIView(acknowList: store.packageList!)
     }
+    .fileImporter(
+      isPresented: $store.isImportingGPXRoute,
+      allowedContentTypes: [.gpx],
+      onCompletion: { store.send(.view(.gpxFileSelected($0))) }
+    )
   }
 }
 
 // MARK: - Subviews
+
+private struct GPXRouteRow: View {
+  @Environment(\.colorSchemeContrast) private var colorSchemeContrast
+  @Shared(.userSettings) var userSettings
+  let store: StoreOf<SettingsFeature>
+
+  var body: some View {
+    HStack(alignment: .top) {
+      VStack(alignment: .leading, spacing: .grid(1)) {
+        Text("Route Overlay")
+          .font(.body)
+        if let route = userSettings.gpxRoute {
+          Text(route.name ?? "GPX Route")
+            .foregroundColor(colorSchemeContrast.isIncreased ? Color.textPrimary : Color.textSilent)
+            .font(.subheadline)
+            .lineLimit(1)
+        } else {
+          Text("Import a GPX file to show a route on the map")
+            .foregroundColor(colorSchemeContrast.isIncreased ? Color.textPrimary : Color.textSilent)
+            .font(.subheadline)
+        }
+      }
+
+      Spacer()
+
+      if userSettings.gpxRoute != nil {
+        Button(role: .destructive) {
+          store.send(.view(.gpxRouteRemoved))
+        } label: {
+          Image(systemName: "trash")
+            .foregroundStyle(.red)
+        }
+        .buttonStyle(.plain)
+      } else {
+        Button {
+          store.send(.view(.gpxImportButtonTapped))
+        } label: {
+          Text("Import")
+            .font(.subheadline)
+        }
+        .buttonStyle(.plain)
+      }
+    }
+    .accessibilityElement(children: .combine)
+  }
+}
 
 private struct ObservationModeRow: View {
   @Environment(\.colorSchemeContrast) private var colorSchemeContrast
@@ -354,6 +410,12 @@ private struct SettingsInfoLink: View {
     }
     .font(.body)
   }
+}
+
+// MARK: - UTType
+
+private extension UTType {
+  static let gpx = UTType(importedAs: "com.topografix.gpx")
 }
 
 // MARK: - Preview

--- a/CriticalMapsKit/Sources/SettingsFeature/SettingsView.swift
+++ b/CriticalMapsKit/Sources/SettingsFeature/SettingsView.swift
@@ -122,6 +122,7 @@ public struct SettingsView: View {
     .navigationDestination(isPresented: $store.destination.acknowledgements) {
       AcknowListSwiftUIView(acknowList: store.packageList!)
     }
+    .alert($store.scope(state: \.alert, action: \.alert))
     .fileImporter(
       isPresented: $store.isImportingGPXRoute,
       allowedContentTypes: [.gpx],

--- a/CriticalMapsKit/Sources/SettingsFeature/SettingsView.swift
+++ b/CriticalMapsKit/Sources/SettingsFeature/SettingsView.swift
@@ -140,15 +140,16 @@ private struct GPXRouteRow: View {
   var body: some View {
     HStack(alignment: .top) {
       VStack(alignment: .leading, spacing: .grid(1)) {
-        Text("Route Overlay")
+        Text(L10n.Settings.RouteOverlay.title)
           .font(.body)
+				
         if let route = userSettings.gpxRoute {
-          Text(route.name ?? "GPX Route")
+          Text(route.name ?? L10n.Settings.RouteOverlay.title)
             .foregroundColor(colorSchemeContrast.isIncreased ? Color.textPrimary : Color.textSilent)
             .font(.subheadline)
             .lineLimit(1)
         } else {
-          Text("Import a GPX file to show a route on the map")
+          Text(L10n.Settings.RouteOverlay.description)
             .foregroundColor(colorSchemeContrast.isIncreased ? Color.textPrimary : Color.textSilent)
             .font(.subheadline)
         }
@@ -160,7 +161,7 @@ private struct GPXRouteRow: View {
         Button(role: .destructive) {
           store.send(.view(.gpxRouteRemoved))
         } label: {
-          Image(systemName: "trash")
+          Image(systemName: "xmark.circle")
             .foregroundStyle(.red)
         }
         .buttonStyle(.plain)
@@ -168,7 +169,7 @@ private struct GPXRouteRow: View {
         Button {
           store.send(.view(.gpxImportButtonTapped))
         } label: {
-          Text("Import")
+          Text(L10n.Settings.RouteOverlay.import)
             .font(.subheadline)
         }
         .buttonStyle(.plain)

--- a/CriticalMapsKit/Sources/SharedModels/GPXRoute.swift
+++ b/CriticalMapsKit/Sources/SharedModels/GPXRoute.swift
@@ -19,18 +19,12 @@ public enum GPXParser {
     parser.delegate = delegate
     parser.parse()
     guard !delegate.coordinates.isEmpty else { return nil }
-    let name = delegate.name.flatMap { $0.isEmpty ? nil : $0 }
-    return GPXRoute(name: name, coordinates: delegate.coordinates)
+    return GPXRoute(coordinates: delegate.coordinates)
   }
 }
 
 private final class ParserDelegate: NSObject, XMLParserDelegate, @unchecked Sendable {
-  var name: String?
   var coordinates: [Coordinate] = []
-
-  private var isCapturingName = false
-  private var capturedText = ""
-  private var hasSetName = false
 
   func parser(
     _ parser: XMLParser,
@@ -41,38 +35,15 @@ private final class ParserDelegate: NSObject, XMLParserDelegate, @unchecked Send
   ) {
     switch elementName {
     case "trkpt", "wpt", "rtept":
-      guard let latStr = attributes["lat"], let lonStr = attributes["lon"],
-            let lat = Double(latStr), let lon = Double(lonStr) else { return }
+      guard
+        let latStr = attributes["lat"],
+        let lonStr = attributes["lon"],
+        let lat = Double(latStr),
+        let lon = Double(lonStr)
+      else { return }
       coordinates.append(Coordinate(latitude: lat, longitude: lon))
-    case "name":
-      isCapturingName = true
-      capturedText = ""
     default:
       break
-    }
-  }
-
-  func parser(_ parser: XMLParser, foundCharacters string: String) {
-    if isCapturingName {
-      capturedText += string
-    }
-  }
-
-  func parser(
-    _ parser: XMLParser,
-    didEndElement elementName: String,
-    namespaceURI _: String?,
-    qualifiedName _: String?
-  ) {
-    if elementName == "name" {
-      isCapturingName = false
-      if !hasSetName {
-        let trimmed = capturedText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty {
-          name = trimmed
-          hasSetName = true
-        }
-      }
     }
   }
 }

--- a/CriticalMapsKit/Sources/SharedModels/GPXRoute.swift
+++ b/CriticalMapsKit/Sources/SharedModels/GPXRoute.swift
@@ -10,15 +10,35 @@ public struct GPXRoute: Codable, Equatable, Sendable {
   }
 }
 
+// MARK: - Parse Error
+
+public enum GPXParseError: LocalizedError, Equatable, Sendable {
+  case malformedXML
+  case noCoordinatesFound
+
+  public var errorDescription: String? {
+    switch self {
+    case .malformedXML:
+      "The file could not be read as a valid GPX file."
+    case .noCoordinatesFound:
+      "The GPX file does not contain any route coordinates."
+    }
+  }
+}
+
 // MARK: - Parser
 
 public enum GPXParser {
-  public static func parse(data: Data) -> GPXRoute? {
+  public static func parse(data: Data) throws -> GPXRoute {
     let delegate = ParserDelegate()
     let parser = XMLParser(data: data)
     parser.delegate = delegate
-    parser.parse()
-    guard !delegate.coordinates.isEmpty else { return nil }
+    guard parser.parse() else {
+      throw GPXParseError.malformedXML
+    }
+    guard !delegate.coordinates.isEmpty else {
+      throw GPXParseError.noCoordinatesFound
+    }
     return GPXRoute(coordinates: delegate.coordinates)
   }
 }

--- a/CriticalMapsKit/Sources/SharedModels/GPXRoute.swift
+++ b/CriticalMapsKit/Sources/SharedModels/GPXRoute.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+public struct GPXRoute: Codable, Equatable, Sendable {
+  public var name: String?
+  public var coordinates: [Coordinate]
+
+  public init(name: String? = nil, coordinates: [Coordinate]) {
+    self.name = name
+    self.coordinates = coordinates
+  }
+}
+
+// MARK: - Parser
+
+public enum GPXParser {
+  public static func parse(data: Data) -> GPXRoute? {
+    let delegate = ParserDelegate()
+    let parser = XMLParser(data: data)
+    parser.delegate = delegate
+    parser.parse()
+    guard !delegate.coordinates.isEmpty else { return nil }
+    let name = delegate.name.flatMap { $0.isEmpty ? nil : $0 }
+    return GPXRoute(name: name, coordinates: delegate.coordinates)
+  }
+}
+
+private final class ParserDelegate: NSObject, XMLParserDelegate, @unchecked Sendable {
+  var name: String?
+  var coordinates: [Coordinate] = []
+
+  private var isCapturingName = false
+  private var capturedText = ""
+  private var hasSetName = false
+
+  func parser(
+    _ parser: XMLParser,
+    didStartElement elementName: String,
+    namespaceURI _: String?,
+    qualifiedName _: String?,
+    attributes: [String: String] = [:]
+  ) {
+    switch elementName {
+    case "trkpt", "wpt", "rtept":
+      guard let latStr = attributes["lat"], let lonStr = attributes["lon"],
+            let lat = Double(latStr), let lon = Double(lonStr) else { return }
+      coordinates.append(Coordinate(latitude: lat, longitude: lon))
+    case "name":
+      isCapturingName = true
+      capturedText = ""
+    default:
+      break
+    }
+  }
+
+  func parser(_ parser: XMLParser, foundCharacters string: String) {
+    if isCapturingName {
+      capturedText += string
+    }
+  }
+
+  func parser(
+    _ parser: XMLParser,
+    didEndElement elementName: String,
+    namespaceURI _: String?,
+    qualifiedName _: String?
+  ) {
+    if elementName == "name" {
+      isCapturingName = false
+      if !hasSetName {
+        let trimmed = capturedText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+          name = trimmed
+          hasSetName = true
+        }
+      }
+    }
+  }
+}

--- a/CriticalMapsKit/Sources/SharedModels/UserSettings.swift
+++ b/CriticalMapsKit/Sources/SharedModels/UserSettings.swift
@@ -7,13 +7,16 @@ import SwiftUI
 public struct UserSettings: Codable, Equatable, Sendable {
   public var isObservationModeEnabled: Bool
   public var showInfoViewEnabled: Bool
+  public var gpxRoute: GPXRoute?
 
   public init(
     enableObservationMode: Bool = false,
-    showInfoViewEnabled: Bool = true
+    showInfoViewEnabled: Bool = true,
+    gpxRoute: GPXRoute? = nil
   ) {
     isObservationModeEnabled = enableObservationMode
     self.showInfoViewEnabled = showInfoViewEnabled
+    self.gpxRoute = gpxRoute
   }
 }
 

--- a/CriticalMapsKit/Sources/Styleguide/DataTile.swift
+++ b/CriticalMapsKit/Sources/Styleguide/DataTile.swift
@@ -36,13 +36,10 @@ public struct DataTile<Content: View>: View {
     .frame(width: 100)
     .conditionalBackground(shouldUseGlassEffect: false)
     .adaptiveClipShape()
-    .if(!.iOS26) { view in
-      view
-        .overlay(
-          RoundedRectangle(cornerRadius: .grid(3), style: .continuous)
-            .stroke(Color.textPrimary.opacity(0.2), lineWidth: 1)
-        )
-    }
+    .overlay(
+      RoundedRectangle(cornerRadius: .grid(3), style: .continuous)
+        .stroke(Color.textPrimary.opacity(0.15), lineWidth: 1)
+    )
     .accessibilityElement(children: .combine)
   }
 }

--- a/CriticalMapsKit/Tests/SettingsFeatureTests/GPXRouteFeatureTests.swift
+++ b/CriticalMapsKit/Tests/SettingsFeatureTests/GPXRouteFeatureTests.swift
@@ -1,6 +1,6 @@
 import ComposableArchitecture
 import Foundation
-import SettingsFeature
+@testable import SettingsFeature
 import SharedModels
 import Testing
 

--- a/CriticalMapsKit/Tests/SettingsFeatureTests/GPXRouteFeatureTests.swift
+++ b/CriticalMapsKit/Tests/SettingsFeatureTests/GPXRouteFeatureTests.swift
@@ -22,7 +22,7 @@ struct GPXRouteFeatureTests {
   }
 
   @Test
-  func `file selected with failure clears importing flag`() async {
+  func `file selected with failure shows alert`() async {
     var initialState = SettingsFeature.State()
     initialState.isImportingGPXRoute = true
 
@@ -33,6 +33,7 @@ struct GPXRouteFeatureTests {
 
     await store.send(.view(.gpxFileSelected(.failure(TestError.stub)))) {
       $0.isImportingGPXRoute = false
+      $0.alert = .gpxImportFailed(error: TestError.stub)
     }
   }
 
@@ -69,7 +70,7 @@ struct GPXRouteFeatureTests {
   }
 
   @Test
-  func `file selected with unparsable content sends no action`() async throws {
+  func `file selected with unparsable content shows alert`() async throws {
     let url = try makeGPXFile(named: "broken", content: "this is not xml at all")
 
     let store = TestStore(
@@ -83,11 +84,13 @@ struct GPXRouteFeatureTests {
     await store.send(.view(.gpxFileSelected(.success(url)))) {
       $0.isImportingGPXRoute = false
     }
-    // no gpxRouteParsed action expected
+    await store.receive(\.gpxImportFailed) {
+      $0.alert = .gpxImportFailed(error: GPXParseError.malformedXML)
+    }
   }
 
   @Test
-  func `file selected with GPX having no trackpoints sends no action`() async throws {
+  func `file selected with GPX having no trackpoints shows alert`() async throws {
     let url = try makeGPXFile(named: "empty", content: emptyTrackGPXContent)
 
     let store = TestStore(
@@ -101,7 +104,9 @@ struct GPXRouteFeatureTests {
     await store.send(.view(.gpxFileSelected(.success(url)))) {
       $0.isImportingGPXRoute = false
     }
-    // no gpxRouteParsed action expected
+    await store.receive(\.gpxImportFailed) {
+      $0.alert = .gpxImportFailed(error: GPXParseError.noCoordinatesFound)
+    }
   }
 
   @Test
@@ -148,15 +153,15 @@ struct GPXRouteFeatureTests {
 @Suite("GPXParser")
 struct GPXParserTests {
   @Test
-  func `parses track points`() {
-    let route = GPXParser.parse(data: Data(validGPXContent.utf8))
-    #expect(route?.coordinates.count == 3)
-    #expect(route?.coordinates.first == Coordinate(latitude: 52.5200, longitude: 13.4050))
-    #expect(route?.coordinates.last == Coordinate(latitude: 52.5220, longitude: 13.4070))
+  func `parses track points`() throws {
+    let route = try GPXParser.parse(data: Data(validGPXContent.utf8))
+    #expect(route.coordinates.count == 3)
+    #expect(route.coordinates.first == Coordinate(latitude: 52.5200, longitude: 13.4050))
+    #expect(route.coordinates.last == Coordinate(latitude: 52.5220, longitude: 13.4070))
   }
 
   @Test
-  func `parses waypoints`() {
+  func `parses waypoints`() throws {
     let gpx = """
     <?xml version="1.0"?>
     <gpx version="1.1">
@@ -164,39 +169,41 @@ struct GPXParserTests {
       <wpt lat="48.1384" lon="11.5765"><name>Next</name></wpt>
     </gpx>
     """
-    let route = GPXParser.parse(data: Data(gpx.utf8))
-    #expect(route?.coordinates.count == 2)
-    #expect(route?.coordinates.first == Coordinate(latitude: 48.1374, longitude: 11.5755))
+    let route = try GPXParser.parse(data: Data(gpx.utf8))
+    #expect(route.coordinates.count == 2)
+    #expect(route.coordinates.first == Coordinate(latitude: 48.1374, longitude: 11.5755))
   }
 
   @Test
-  func `parses route points`() {
+  func `parses route points`() throws {
     let gpx = """
     <?xml version="1.0"?>
     <gpx version="1.1">
       <rte><rtept lat="52.0" lon="13.0"/><rtept lat="52.1" lon="13.1"/></rte>
     </gpx>
     """
-    let route = GPXParser.parse(data: Data(gpx.utf8))
-    #expect(route?.coordinates.count == 2)
+    let route = try GPXParser.parse(data: Data(gpx.utf8))
+    #expect(route.coordinates.count == 2)
   }
 
   @Test
-  func `returns nil for empty track`() {
-    let route = GPXParser.parse(data: Data(emptyTrackGPXContent.utf8))
-    #expect(route == nil)
+  func `throws noCoordinatesFound for empty track`() {
+    #expect(throws: GPXParseError.noCoordinatesFound) {
+      try GPXParser.parse(data: Data(emptyTrackGPXContent.utf8))
+    }
   }
 
   @Test
-  func `returns nil for invalid XML`() {
-    let route = GPXParser.parse(data: Data("not xml".utf8))
-    #expect(route == nil)
+  func `throws malformedXML for invalid XML`() {
+    #expect(throws: GPXParseError.malformedXML) {
+      try GPXParser.parse(data: Data("not xml".utf8))
+    }
   }
 
   @Test
-  func `does not set name from XML`() {
-    let route = GPXParser.parse(data: Data(validGPXContent.utf8))
-    #expect(route?.name == nil)
+  func `does not set name from XML`() throws {
+    let route = try GPXParser.parse(data: Data(validGPXContent.utf8))
+    #expect(route.name == nil)
   }
 }
 

--- a/CriticalMapsKit/Tests/SettingsFeatureTests/GPXRouteFeatureTests.swift
+++ b/CriticalMapsKit/Tests/SettingsFeatureTests/GPXRouteFeatureTests.swift
@@ -1,0 +1,234 @@
+import ComposableArchitecture
+import Foundation
+import SettingsFeature
+import SharedModels
+import Testing
+
+@Suite("GPX Route Feature")
+@MainActor
+struct GPXRouteFeatureTests {
+  // MARK: - Reducer
+
+  @Test
+  func `import button tapped sets is importing flag`() async {
+    let store = TestStore(
+      initialState: SettingsFeature.State(),
+      reducer: { SettingsFeature() }
+    )
+
+    await store.send(.view(.gpxImportButtonTapped)) {
+      $0.isImportingGPXRoute = true
+    }
+  }
+
+  @Test
+  func `file selected with failure clears importing flag`() async {
+    var initialState = SettingsFeature.State()
+    initialState.isImportingGPXRoute = true
+
+    let store = TestStore(
+      initialState: initialState,
+      reducer: { SettingsFeature() }
+    )
+
+    await store.send(.view(.gpxFileSelected(.failure(TestError.stub)))) {
+      $0.isImportingGPXRoute = false
+    }
+  }
+
+  @Test
+  func `file selected with valid GPX stores route in user settings`() async throws {
+    @Shared(.userSettings) var userSettings = UserSettings()
+    let url = try makeGPXFile(named: "Sternfahrt_2026", content: validGPXContent)
+
+    let store = TestStore(
+      initialState: SettingsFeature.State(),
+      reducer: { SettingsFeature() }
+    )
+
+    await store.send(.view(.gpxImportButtonTapped)) {
+      $0.isImportingGPXRoute = true
+    }
+    await store.send(.view(.gpxFileSelected(.success(url)))) {
+      $0.isImportingGPXRoute = false
+    }
+
+    let expectedRoute = GPXRoute(
+      name: url.lastPathComponent,
+      coordinates: [
+        Coordinate(latitude: 52.5200, longitude: 13.4050),
+        Coordinate(latitude: 52.5210, longitude: 13.4060),
+        Coordinate(latitude: 52.5220, longitude: 13.4070)
+      ]
+    )
+    await store.receive(\.gpxRouteParsed) {
+      $0.$userSettings.withLock { value in value.gpxRoute = expectedRoute }
+    }
+
+    #expect(userSettings.gpxRoute == expectedRoute)
+  }
+
+  @Test
+  func `file selected with unparsable content sends no action`() async throws {
+    let url = try makeGPXFile(named: "broken", content: "this is not xml at all")
+
+    let store = TestStore(
+      initialState: SettingsFeature.State(),
+      reducer: { SettingsFeature() }
+    )
+
+    await store.send(.view(.gpxImportButtonTapped)) {
+      $0.isImportingGPXRoute = true
+    }
+    await store.send(.view(.gpxFileSelected(.success(url)))) {
+      $0.isImportingGPXRoute = false
+    }
+    // no gpxRouteParsed action expected
+  }
+
+  @Test
+  func `file selected with GPX having no trackpoints sends no action`() async throws {
+    let url = try makeGPXFile(named: "empty", content: emptyTrackGPXContent)
+
+    let store = TestStore(
+      initialState: SettingsFeature.State(),
+      reducer: { SettingsFeature() }
+    )
+
+    await store.send(.view(.gpxImportButtonTapped)) {
+      $0.isImportingGPXRoute = true
+    }
+    await store.send(.view(.gpxFileSelected(.success(url)))) {
+      $0.isImportingGPXRoute = false
+    }
+    // no gpxRouteParsed action expected
+  }
+
+  @Test
+  func `route removed clears GPX route from user settings`() async {
+    @Shared(.userSettings) var userSettings = UserSettings(
+      gpxRoute: GPXRoute(name: "Test Route", coordinates: [Coordinate(latitude: 52.5, longitude: 13.4)])
+    )
+
+    let store = TestStore(
+      initialState: SettingsFeature.State(),
+      reducer: { SettingsFeature() }
+    )
+
+    await store.send(.view(.gpxRouteRemoved)) {
+      $0.$userSettings.withLock { value in value.gpxRoute = nil }
+    }
+
+    #expect(userSettings.gpxRoute == nil)
+  }
+
+  @Test
+  func `gpx route parsed stores route in user settings`() async {
+    @Shared(.userSettings) var userSettings = UserSettings()
+
+    let route = GPXRoute(
+      name: "Berlin Ride",
+      coordinates: [Coordinate(latitude: 52.5200, longitude: 13.4050)]
+    )
+    let store = TestStore(
+      initialState: SettingsFeature.State(),
+      reducer: { SettingsFeature() }
+    )
+
+    await store.send(.gpxRouteParsed(route)) {
+      $0.$userSettings.withLock { value in value.gpxRoute = route }
+    }
+
+    #expect(userSettings.gpxRoute == route)
+  }
+}
+
+// MARK: - GPXParser Unit Tests
+
+@Suite("GPXParser")
+struct GPXParserTests {
+  @Test
+  func `parses track points`() {
+    let route = GPXParser.parse(data: Data(validGPXContent.utf8))
+    #expect(route?.coordinates.count == 3)
+    #expect(route?.coordinates.first == Coordinate(latitude: 52.5200, longitude: 13.4050))
+    #expect(route?.coordinates.last == Coordinate(latitude: 52.5220, longitude: 13.4070))
+  }
+
+  @Test
+  func `parses waypoints`() {
+    let gpx = """
+    <?xml version="1.0"?>
+    <gpx version="1.1">
+      <wpt lat="48.1374" lon="11.5755"><name>Munich</name></wpt>
+      <wpt lat="48.1384" lon="11.5765"><name>Next</name></wpt>
+    </gpx>
+    """
+    let route = GPXParser.parse(data: Data(gpx.utf8))
+    #expect(route?.coordinates.count == 2)
+    #expect(route?.coordinates.first == Coordinate(latitude: 48.1374, longitude: 11.5755))
+  }
+
+  @Test
+  func `parses route points`() {
+    let gpx = """
+    <?xml version="1.0"?>
+    <gpx version="1.1">
+      <rte><rtept lat="52.0" lon="13.0"/><rtept lat="52.1" lon="13.1"/></rte>
+    </gpx>
+    """
+    let route = GPXParser.parse(data: Data(gpx.utf8))
+    #expect(route?.coordinates.count == 2)
+  }
+
+  @Test
+  func `returns nil for empty track`() {
+    let route = GPXParser.parse(data: Data(emptyTrackGPXContent.utf8))
+    #expect(route == nil)
+  }
+
+  @Test
+  func `returns nil for invalid XML`() {
+    let route = GPXParser.parse(data: Data("not xml".utf8))
+    #expect(route == nil)
+  }
+
+  @Test
+  func `does not set name from XML`() {
+    let route = GPXParser.parse(data: Data(validGPXContent.utf8))
+    #expect(route?.name == nil)
+  }
+}
+
+// MARK: - Helpers
+
+private enum TestError: Error { case stub }
+
+private func makeGPXFile(named name: String, content: String) throws -> URL {
+  let url = FileManager.default.temporaryDirectory
+    .appendingPathComponent(name)
+    .appendingPathExtension("gpx")
+  try content.write(to: url, atomically: true, encoding: .utf8)
+  return url
+}
+
+private let validGPXContent = """
+<?xml version="1.0"?>
+<gpx version="1.1" creator="Test">
+  <trk>
+    <name>Test Track</name>
+    <trkseg>
+      <trkpt lat="52.5200" lon="13.4050"/>
+      <trkpt lat="52.5210" lon="13.4060"/>
+      <trkpt lat="52.5220" lon="13.4070"/>
+    </trkseg>
+  </trk>
+</gpx>
+"""
+
+private let emptyTrackGPXContent = """
+<?xml version="1.0"?>
+<gpx version="1.1">
+  <trk><trkseg></trkseg></trk>
+</gpx>
+"""

--- a/iOS/Info.plist
+++ b/iOS/Info.plist
@@ -115,6 +115,29 @@
 	<array>
 		<string>arm64</string>
 	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>com.topografix.gpx</string>
+			<key>UTTypeDescription</key>
+			<string>GPX File</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.xml</string>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>gpx</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/gpx+xml</string>
+			</dict>
+		</dict>
+	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
## 📝 Docs

- [x] Did you update the [CHANGELOG.md](https://github.com/criticalmaps/criticalmaps-ios/blob/master/CHANGELOG.md)?

## 📲 What

Adds GPX route overlay support to the app:

- **Settings**: New "Route Overlay" section with a file importer to pick a `.gpx` file from the device. Shows the loaded filename with a remove button once a route is active. Parsing failures surface as an alert.
- **Map**: Renders the imported GPX route as a blue polyline overlay (`MKPolyline`) above roads. Overlay updates reactively via `@Shared(.userSettings)`.
- **Info overlay**: A conditional fourth tile appears in the expanded info view when a route is loaded, showing the route name and a × button to clear it.
- **Persistence**: The active route is stored in `UserSettings` (file-backed `@Shared`) and survives app restarts.

## 🤔 Why

Critical Mass rides often follow a published route. This feature lets participants import a GPX file and see it overlaid on the live map, making it easier to stay on course during the ride.

## 👀 See

- `UTImportedTypeDeclarations` for `com.topografix.gpx` added to `Info.plist` — required so `.gpx` files aren't greyed out in the system file picker.
- `GPXParser` uses Foundation's `XMLParser` (no third-party dependency) and now throws typed `GPXParseError` values (`malformedXML` / `noCoordinatesFound`), propagated to the user as an alert.
- All new UI strings are localised across all 9 supported languages (en, de, es, fr, it, pl, pt-BR, pt-PT, tr).

| Before 🐛 | After 🦋 |
| --- | --- |
| No route overlay support | GPX route visible as blue polyline on map |
| Settings has no import option | "Route Overlay" row with Import / filename + remove |
| Info overlay always shows 3 tiles | 4th tile appears when a route is active |

## ♿️ Accessibility

- [x] Works with VoiceOver — `GPXRouteTile` has an `accessibilityLabel` combining tile title and route name; `GPXRouteRow` uses `.accessibilityElement(children: .combine)`
- [x] Supports Dynamic Type
